### PR TITLE
Implement a single interface for Dakota

### DIFF
--- a/dakota/dakota.py
+++ b/dakota/dakota.py
@@ -4,6 +4,7 @@
 import os
 import subprocess
 import importlib
+from .dakota_utils import is_dakota_installed
 
 
 class Dakota(object):
@@ -76,6 +77,8 @@ class Dakota(object):
 
     def run(self):
         """Run the Dakota experiment."""
+        if is_dakota_installed() is False:
+            raise OSError('Dakota must be installed and in execution path.')
         if os.path.exists(self.input_file) is False:
             raise IOError('Dakota input file not found.')
         else:

--- a/dakota/dakota.py
+++ b/dakota/dakota.py
@@ -10,7 +10,35 @@ class Dakota(object):
     """Set up and run a Dakota experiment."""
 
     def __init__(self, input_file=None, method=None):
-        """Create a new Dakota experiment."""
+        """Create a new Dakota experiment.
+
+        One of either ``input_file`` or ``method`` is required, and
+        they're exclusive. Use ``input_file`` to run Dakota with an
+        existing input file. Use ``method`` to configure a new
+        experiment and create a new input file.
+
+        Parameters
+        ----------
+        input_file: str
+          The path to a Dakota input file.
+        method : str
+          The desired Dakota method (e.g., `vector_parameter_study` or
+          `polynomial_chaos`) to use in an experiment.
+
+        Examples
+        --------
+        Run a Dakota experiment with an existing input file:
+
+        >>> d = Dakota(input_file='/path/to/dakota.in')
+        >>> d.run()
+
+        Configure and run a vector parameter study experiment:
+
+        >>> d = Dakota(method='vector_parameter_study')
+        >>> d.create_input_file()
+        >>> d.run()
+
+        """
         if [input_file, method].count(None) != 1:
             raise TypeError('Must specify exactly one input file or method.')
 
@@ -24,7 +52,17 @@ class Dakota(object):
             self.method = module.method()
 
     def create_input_file(self, input_file=None):
-        """Create a Dakota input file on the file system."""
+        """Create a Dakota input file on the file system.
+
+        Only instances created with ``method`` can create a new Dakota
+        input file.
+
+        Parameters
+        ----------
+        input_file: str, optional
+          A path/name for a new Dakota input file.
+
+        """
         if hasattr(self, 'method') is False:
             raise TypeError('Instance created with `input_file` is read-only.')
         if input_file is not None:

--- a/dakota/dakota.py
+++ b/dakota/dakota.py
@@ -1,207 +1,47 @@
 #! /usr/bin/env python
 """Interface to the Dakota iterative systems analysis toolkit."""
 
+import os
 import subprocess
-import re
+import importlib
 
-
-def is_dakota_installed():
-    """Check whether Dakota is installed and in the execution path."""
-    try:
-        subprocess.call(['dakota', '--version'])
-    except OSError:
-        return False
-    else:
-        return True
 
 class Dakota(object):
-    """Describe and run a Dakota experiment."""
+    """Set up and run a Dakota experiment."""
 
-    def __init__(self, input_file='dakota.in'):
-        """Create a new Dakota experiment with default parameters."""
-        self.model = None
-        self.input_file = input_file
+    def __init__(self, input_file=None, method=None):
+        """Create a new Dakota experiment."""
+        if [input_file, method].count(None) != 1:
+            raise TypeError('Must specify exactly one input file or method.')
+
+        self.input_file = 'dakota.in'
         self.output_file = 'dakota.out'
-        self.data_file = 'dakota.dat'
 
-        self.method = 'multidim_parameter_study'
-        self.partitions = [8, 8]
-
-        self.variable_type = 'continuous_design'
-        self.n_variables = 2
-        self.variable_descriptors = ['x1', 'x2']
-        self.upper_bounds = [2.0, 2.0]
-        self.lower_bounds = [-2.0, -2.0]
-
-        self.interface = 'direct'
-        self.analysis_driver = 'rosenbrock'
-        self.parameters_file = 'params.in'
-        self.results_file = 'results.out'
-
-        self.n_responses = 1
-        self.is_objective_function = False
-        self.response_descriptors = ['r1']
-        self.response_files = []
-        self.response_statistics = []
-
-    def run(self):
-        """Run the specified Dakota experiment."""
-        r = subprocess.call(['dakota',
-                             '-i', self.input_file,
-                             '-o', self.output_file])
+        if input_file is not None:
+            self.input_file = input_file
+        else:
+            module = importlib.import_module('dakota.' + method)
+            self.method = module.method()
 
     def create_input_file(self, input_file=None):
         """Create a Dakota input file on the file system."""
+        if hasattr(self, 'method') is False:
+            raise TypeError('Instance created with `input_file` is read-only.')
         if input_file is not None:
             self.input_file = input_file
         with open(self.input_file, 'w') as fp:
-            fp.write(self.environment_block())
-            fp.write(self.method_block())
-            fp.write(self.variables_block())
-            fp.write(self.interface_block())
-            fp.write(self.responses_block())
+            fp.write(self.method.environment_block())
+            fp.write(self.method.method_block())
+            fp.write(self.method.variables_block())
+            fp.write(self.method.interface_block())
+            fp.write(self.method.responses_block())
 
-    def environment_block(self):
-        """Define the environment block of a Dakota input file."""
-        s = '# Dakota input file\n' \
-            + 'environment\n' \
-            + '  tabular_data\n' \
-            + '    tabular_data_file = {!r}\n\n'.format(self.data_file)
-        return(s)
-
-    def method_block(self):
-        """Define the method block of a Dakota input file."""
-        s = 'method\n' \
-            + '  {}\n'.format(self.method) \
-            + '    partitions ='
-        for p in self.partitions:
-            s += ' {}'.format(p)
-        s += '\n\n'
-        return(s)
-
-    def variables_block(self):
-        """Define the variables block of a Dakota input file."""
-        s = 'variables\n' \
-            + '  {0} = {1}\n'.format(self.variable_type, self.n_variables) \
-            + '    upper_bounds ='
-        for b in self.upper_bounds:
-            s += ' {}'.format(b)
-        s += '\n' \
-             + '    lower_bounds ='
-        for b in self.lower_bounds:
-            s += ' {}'.format(b)
-        s += '\n' \
-             + '    descriptors ='
-        for vd in self.variable_descriptors:
-            s += ' {!r}'.format(vd)
-        s += '\n\n'
-        return(s)
-
-    def interface_block(self):
-        """Define the interface block of a Dakota input file."""
-        s = 'interface\n' \
-            + '  {}\n'.format(self.interface) \
-            + '  analysis_driver = {!r}\n'.format(self.analysis_driver)
-        if self.model is not None:
-            s += '  analysis_components = {!r}'.format(self.model)
-            for pair in zip(self.response_files, self.response_statistics):
-                s += ' \'{0[0]}:{0[1]}\''.format(pair)
-            s += '\n'
-        if self.interface is not 'direct':
-            s += '  parameters_file = {!r}\n'.format(self.parameters_file) \
-                 + '  results_file = {!r}\n'.format(self.results_file) \
-                 + '  work_directory\n' \
-                 + '    named \'run\'\n' \
-                 + '    directory_tag\n' \
-                 + '    directory_save\n' \
-                 + '  file_save\n'
-        s += '\n'
-        return(s)
-
-    def responses_block(self):
-        """Define the responses block of a Dakota input file."""
-        s = 'responses\n'
-        if self.is_objective_function:
-            s += '  objective_functions = {}\n'.format(self.n_responses)
+    def run(self):
+        """Run the Dakota experiment."""
+        if os.path.exists(self.input_file) is False:
+            raise IOError('Dakota input file not found.')
         else:
-            s += '  response_functions = {}\n'.format(self.n_responses)
-        s += '    response_descriptors ='
-        for rd in self.response_descriptors:
-            s += ' {!r}'.format(rd)
-        s += '\n' \
-             + '  no_gradients\n' \
-             + '  no_hessians\n'
-        return(s)
+            r = subprocess.call(['dakota',
+                                 '-i', self.input_file,
+                                 '-o', self.output_file])
 
-def get_labels(params_file):
-    """Extract labels from a Dakota parameters file."""
-    labels = []
-    try:
-        with open(params_file, 'r') as fp:
-            for line in fp:
-                if re.search('ASV_', line):
-                    labels.append(''.join(re.findall(':(\S+)', line)))
-    except IOError:
-        return None
-    else:
-        return(labels)
-
-def get_analysis_components(params_file):
-    """Extract the analysis components from a Dakota parameters file.
-
-    The analysis components are returned as a list. First is the name
-    of the model being run by Dakota, followed by dicts containing an
-    output file to analyze and the statistic to apply to the file.
-
-    Parameters
-    ----------
-    params_file : str
-      The path to a Dakota parameters file.
-
-    Returns
-    -------
-    list
-      A list of analysis components for the Dakota experiment.
-
-    Examples
-    --------
-    Extract the analysis components from a Dakota parameters file:
-
-    >>> ac = get_analysis_components(params_file)
-    >>> ac.pop(0)
-    'hydrotrend'
-    >>> ac.pop(0)
-    {'file': 'HYDROASCII.QS', 'statistic': 'median'}
-
-    Notes
-    -----
-    The syntax expected by this function is defined in the Dakota
-    input file; e.g., for the example cited above, the 'interface'
-    section of the input file contains the line:
-
-      analysis_components = 'hydrotrend' 'HYDROASCII.QS:median'
-
-    """
-    ac = []
-    try:
-        with open(params_file, 'r') as fp:
-            for line in fp:
-                if re.search('AC_1', line):
-                    ac.append(line.split('AC_1')[0].strip())
-                elif re.search('AC_', line):
-                    parts = re.split(':', re.split('AC_', line)[0])
-                    ac.append({'file':parts[0].strip(),
-                               'statistic':parts[1].strip()})
-    except IOError:
-        return None
-    else:
-        return(ac)    
-
-def write_results(results_file, array, labels):
-    """Write a Dakota results file from an input numpy array."""
-    try:
-        with open(results_file, 'w') as fp:
-            for i in range(len(array)):
-                fp.write('{0s}\t{1}\n'.format(array[i], labels[i]))
-    except IOError:
-        raise

--- a/dakota/dakota_base.py
+++ b/dakota/dakota_base.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""A base class for all Dakota experiments."""
+"""An abstract base class for all Dakota experiments."""
 
 from abc import ABCMeta, abstractmethod
 
@@ -13,18 +13,14 @@ class DakotaBase(object):
         """Create a set of default experiment parameters."""
         self.model = None
         self.data_file = 'dakota.dat'
-
         self.method = None
-
         self.variable_type = 'continuous_design'
         self.n_variables = 0
         self.variable_descriptors = []
-
         self.interface = 'direct'
         self.analysis_driver = 'rosenbrock'
         self.parameters_file = 'params.in'
         self.results_file = 'results.out'
-
         self.n_responses = 0
         self.is_objective_function = False
         self.response_descriptors = []

--- a/dakota/dakota_base.py
+++ b/dakota/dakota_base.py
@@ -1,0 +1,113 @@
+#! /usr/bin/env python
+"""A base class for all Dakota experiments."""
+
+from abc import ABCMeta, abstractmethod
+
+
+class DakotaBase(object):
+    """Describe features common to all Dakota experiments."""
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def __init__(self):
+        """Create a set of default experiment parameters."""
+        self.model = None
+        # self.input_file = 'dakota.in'
+        # self.output_file = 'dakota.out'
+        self.data_file = 'dakota.dat'
+
+        self.method = None
+
+        self.variable_type = 'continuous_design'
+        self.n_variables = 0
+        self.variable_descriptors = []
+
+        self.interface = 'direct'
+        self.analysis_driver = 'rosenbrock'
+        self.parameters_file = 'params.in'
+        self.results_file = 'results.out'
+
+        self.n_responses = 0
+        self.is_objective_function = False
+        self.response_descriptors = []
+        self.response_files = []
+        self.response_statistics = []
+
+    def autogenerate_descriptors(self):
+        """Quickly make generic variable and response descriptors."""
+        self.variable_descriptors = ['x' + str(i+1) for i in
+                                     range(self.n_variables)]
+        self.response_descriptors = ['y' + str(i+1) for i in
+                                     range(self.n_responses)]
+
+    def environment_block(self):
+        """Define the environment block of a Dakota input file."""
+        s = '# Dakota input file\n' \
+            + 'environment\n' \
+            + '  tabular_data\n' \
+            + '    tabular_data_file = {!r}\n\n'.format(self.data_file)
+        return(s)
+
+    def method_block(self):
+        """Define the method block of a Dakota input file."""
+        s = 'method\n' \
+            + '  {}\n'.format(self.method) \
+            + '    partitions ='
+        for p in self.partitions:
+            s += ' {}'.format(p)
+        s += '\n\n'
+        return(s)
+
+    def variables_block(self):
+        """Define the variables block of a Dakota input file."""
+        s = 'variables\n' \
+            + '  {0} = {1}\n'.format(self.variable_type, self.n_variables) \
+            + '    upper_bounds ='
+        for b in self.upper_bounds:
+            s += ' {}'.format(b)
+        s += '\n' \
+             + '    lower_bounds ='
+        for b in self.lower_bounds:
+            s += ' {}'.format(b)
+        s += '\n' \
+             + '    descriptors ='
+        for vd in self.variable_descriptors:
+            s += ' {!r}'.format(vd)
+        s += '\n\n'
+        return(s)
+
+    def interface_block(self):
+        """Define the interface block of a Dakota input file."""
+        s = 'interface\n' \
+            + '  {}\n'.format(self.interface) \
+            + '  analysis_driver = {!r}\n'.format(self.analysis_driver)
+        if self.model is not None:
+            s += '  analysis_components = {!r}'.format(self.model)
+            for pair in zip(self.response_files, self.response_statistics):
+                s += ' \'{0[0]}:{0[1]}\''.format(pair)
+            s += '\n'
+        if self.interface is not 'direct':
+            s += '  parameters_file = {!r}\n'.format(self.parameters_file) \
+                 + '  results_file = {!r}\n'.format(self.results_file) \
+                 + '  work_directory\n' \
+                 + '    named \'run\'\n' \
+                 + '    directory_tag\n' \
+                 + '    directory_save\n' \
+                 + '  file_save\n'
+        s += '\n'
+        return(s)
+
+    def responses_block(self):
+        """Define the responses block of a Dakota input file."""
+        s = 'responses\n'
+        if self.is_objective_function:
+            s += '  objective_functions = {}\n'.format(self.n_responses)
+        else:
+            s += '  response_functions = {}\n'.format(self.n_responses)
+        s += '    response_descriptors ='
+        for rd in self.response_descriptors:
+            s += ' {!r}'.format(rd)
+        s += '\n' \
+             + '  no_gradients\n' \
+             + '  no_hessians\n'
+        return(s)

--- a/dakota/dakota_base.py
+++ b/dakota/dakota_base.py
@@ -31,13 +31,6 @@ class DakotaBase(object):
         self.response_files = []
         self.response_statistics = []
 
-    def autogenerate_descriptors(self):
-        """Quickly make generic variable and response descriptors."""
-        self.variable_descriptors = ['x' + str(i+1) for i in
-                                     range(self.n_variables)]
-        self.response_descriptors = ['y' + str(i+1) for i in
-                                     range(self.n_responses)]
-
     def environment_block(self):
         """Define the environment block of a Dakota input file."""
         s = '# Dakota input file\n' \
@@ -49,26 +42,14 @@ class DakotaBase(object):
     def method_block(self):
         """Define the method block of a Dakota input file."""
         s = 'method\n' \
-            + '  {}\n'.format(self.method) \
-            + '    partitions ='
-        for p in self.partitions:
-            s += ' {}'.format(p)
-        s += '\n\n'
+            + '  {}\n\n'.format(self.method)
         return(s)
 
     def variables_block(self):
         """Define the variables block of a Dakota input file."""
         s = 'variables\n' \
-            + '  {0} = {1}\n'.format(self.variable_type, self.n_variables) \
-            + '    upper_bounds ='
-        for b in self.upper_bounds:
-            s += ' {}'.format(b)
-        s += '\n' \
-             + '    lower_bounds ='
-        for b in self.lower_bounds:
-            s += ' {}'.format(b)
-        s += '\n' \
-             + '    descriptors ='
+            + '  {0} = {1}\n'.format(self.variable_type, self.n_variables)
+        s += '    descriptors ='
         for vd in self.variable_descriptors:
             s += ' {!r}'.format(vd)
         s += '\n\n'
@@ -109,3 +90,10 @@ class DakotaBase(object):
              + '  no_gradients\n' \
              + '  no_hessians\n'
         return(s)
+
+    def autogenerate_descriptors(self):
+        """Quickly make generic variable and response descriptors."""
+        self.variable_descriptors = ['x' + str(i+1) for i in
+                                     range(self.n_variables)]
+        self.response_descriptors = ['y' + str(i+1) for i in
+                                     range(self.n_responses)]

--- a/dakota/dakota_base.py
+++ b/dakota/dakota_base.py
@@ -12,8 +12,6 @@ class DakotaBase(object):
     def __init__(self):
         """Create a set of default experiment parameters."""
         self.model = None
-        # self.input_file = 'dakota.in'
-        # self.output_file = 'dakota.out'
         self.data_file = 'dakota.dat'
 
         self.method = None

--- a/dakota/dakota_base.py
+++ b/dakota/dakota_base.py
@@ -87,7 +87,7 @@ class DakotaBase(object):
              + '  no_hessians\n'
         return(s)
 
-    def autogenerate_descriptors(self):
+    def generate_descriptors(self):
         """Quickly make generic variable and response descriptors."""
         self.variable_descriptors = ['x' + str(i+1) for i in
                                      range(self.n_variables)]

--- a/dakota/dakota_utils.py
+++ b/dakota/dakota_utils.py
@@ -1,0 +1,88 @@
+#! /usr/bin/env python
+"""Helper functions for processing Dakota parameter and results files."""
+
+import re
+
+
+def get_response_descriptors(params_file):
+    """Extract response descriptors from a Dakota parameters file.
+
+    Parameters
+    ----------
+    params_file : str
+      The path to a Dakota parameters file.
+
+    Returns
+    -------
+    list
+      A list of response descriptors for the Dakota experiment.
+    """
+    labels = []
+    try:
+        with open(params_file, 'r') as fp:
+            for line in fp:
+                if re.search('ASV_', line):
+                    labels.append(''.join(re.findall(':(\S+)', line)))
+    except IOError:
+        return None
+    else:
+        return(labels)
+
+def get_analysis_components(params_file):
+    """Extract the analysis components from a Dakota parameters file.
+
+    The analysis components are returned as a list. First is the name
+    of the model being run by Dakota, followed by dicts containing an
+    output file to analyze and the statistic to apply to the file.
+
+    Parameters
+    ----------
+    params_file : str
+      The path to a Dakota parameters file.
+
+    Returns
+    -------
+    list
+      A list of analysis components for the Dakota experiment.
+
+    Examples
+    --------
+    Extract the analysis components from a Dakota parameters file:
+
+    >>> ac = get_analysis_components(params_file)
+    >>> ac.pop(0)
+    'hydrotrend'
+    >>> ac.pop(0)
+    {'file': 'HYDROASCII.QS', 'statistic': 'median'}
+
+    Notes
+    -----
+    The syntax expected by this function is defined in the Dakota
+    input file; e.g., for the example cited above, the 'interface'
+    section of the input file contains the line:
+
+      analysis_components = 'hydrotrend' 'HYDROASCII.QS:median'
+    """
+    ac = []
+    try:
+        with open(params_file, 'r') as fp:
+            for line in fp:
+                if re.search('AC_1', line):
+                    ac.append(line.split('AC_1')[0].strip())
+                elif re.search('AC_', line):
+                    parts = re.split(':', re.split('AC_', line)[0])
+                    ac.append({'file':parts[0].strip(),
+                               'statistic':parts[1].strip()})
+    except IOError:
+        return None
+    else:
+        return(ac)    
+
+def write_results(results_file, array, labels):
+    """Write a Dakota results file from an input numpy array."""
+    try:
+        with open(results_file, 'w') as fp:
+            for i in range(len(array)):
+                fp.write('{0s}\t{1}\n'.format(array[i], labels[i]))
+    except IOError:
+        raise

--- a/dakota/dakota_utils.py
+++ b/dakota/dakota_utils.py
@@ -1,8 +1,24 @@
 #! /usr/bin/env python
 """Helper functions for processing Dakota parameter and results files."""
 
+import subprocess
 import re
 
+
+def is_dakota_installed():
+    """Check whether Dakota is installed and in the execution path.
+    
+    Returns
+    -------
+    bool
+      True if Dakota is callable.
+    """
+    try:
+        subprocess.call(['dakota', '--version'])
+    except OSError:
+        return False
+    else:
+        return True
 
 def get_response_descriptors(params_file):
     """Extract response descriptors from a Dakota parameters file.

--- a/dakota/dakota_utils.py
+++ b/dakota/dakota_utils.py
@@ -12,6 +12,7 @@ def is_dakota_installed():
     -------
     bool
       True if Dakota is callable.
+
     """
     try:
         subprocess.call(['dakota', '--version'])
@@ -32,6 +33,7 @@ def get_response_descriptors(params_file):
     -------
     list
       A list of response descriptors for the Dakota experiment.
+
     """
     labels = []
     try:
@@ -78,6 +80,7 @@ def get_analysis_components(params_file):
     section of the input file contains the line:
 
       analysis_components = 'hydrotrend' 'HYDROASCII.QS:median'
+
     """
     ac = []
     try:

--- a/dakota/tests/__init__.py
+++ b/dakota/tests/__init__.py
@@ -1,0 +1,5 @@
+"""Unit tests for modules in the dakota package."""
+import os
+
+start_dir = os.path.dirname(__file__)
+data_dir = os.path.join(start_dir, 'data')

--- a/dakota/tests/data/dakota.in
+++ b/dakota/tests/data/dakota.in
@@ -4,13 +4,13 @@ environment
     tabular_data_file = 'dakota.dat'
 
 method
-  multidim_parameter_study
-    partitions = 8 8
+  vector_parameter_study
+    final_point = 1.1 1.3
+    num_steps = 10
 
 variables
   continuous_design = 2
-    upper_bounds = 2.0 2.0
-    lower_bounds = -2.0 -2.0
+    initial_point = -0.3 0.2
     descriptors = 'x1' 'x2'
 
 interface
@@ -19,6 +19,6 @@ interface
 
 responses
   response_functions = 1
-    response_descriptors = 'r1'
+    response_descriptors = 'y1'
   no_gradients
   no_hessians

--- a/dakota/tests/test_dakota.py
+++ b/dakota/tests/test_dakota.py
@@ -11,62 +11,100 @@ import os
 import filecmp
 from nose.tools import *
 from dakota.dakota import Dakota
+from dakota.dakota_utils import is_dakota_installed
 from . import start_dir, data_dir
 
 # Global variables
-input_file = 'dakota.in'
+input_file, \
+    output_file, \
+    data_file, \
+    restart_file = ['dakota.' + ext for ext in ('in','out','dat','rst')]
 alt_input_file = 'alt.in'
 known_file = os.path.join(data_dir, 'dakota.in')
+tmp_files = [input_file, alt_input_file, output_file, data_file, restart_file]
 
 # Fixtures -------------------------------------------------------------
 
 def setup_module():
     """Called before any tests are performed."""
-    print('\n*** Dakota tests')
-    global d
-    d = Dakota()
+    print('\n*** ' + __name__)
 
 def teardown_module():
     """Called after all tests have completed."""
-    if os.path.exists(input_file):
-        os.remove(input_file)
-    if os.path.exists(alt_input_file):
-        os.remove(alt_input_file)
-    if os.path.exists(d.output_file):
-        os.remove(d.output_file)
-    if os.path.exists(d.data_file):
-        os.remove(d.data_file)
-    if os.path.exists('dakota.rst'):
-        os.remove('dakota.rst')
+    for f in tmp_files:
+        if os.path.exists(f): os.remove(f)        
 
 # Tests ----------------------------------------------------------------
 
-def test_constructor_alt_input_file():
-    """Test calling the constructor with an input file."""
-    d1 = Dakota(alt_input_file)
-    assert_equal(d1.input_file, alt_input_file)
+@raises(TypeError)
+def test_init_no_parameters():
+    """Test constructor fails with no parameters."""
+    d = Dakota()
 
-def test_create_default_input_file():
-    """Test the create_input_file method with default parameters."""
+@raises(TypeError)
+def test_init_two_parameters():
+    """Test constructor fails with two parameters."""
+    d = Dakota(input_file='foo.in', method='bar')
+
+def test_init_input_file_parameter():
+    """Test constructor with input_file parameter."""
+    d = Dakota(input_file='foo.in')
+    assert_is_instance(d, Dakota)
+
+def test_init_method_parameter():
+    """Test constructor with method parameter."""
+    d = Dakota(method='vector_parameter_study')
+    assert_is_instance(d, Dakota)
+
+@raises(ImportError)
+def test_init_method_parameter_unknown_module():
+    """Test constructor with method parameter fails with unknown module."""
+    d = Dakota(method='foo')
+
+@raises(TypeError)
+def test_create_input_file_with_input_file():
+    """Test create_input_file fails when instanced with input file."""
+    d = Dakota(input_file='foo.in')
     d.create_input_file()
-    assert_true(os.path.exists(input_file))
 
-def test_create_alt_input_file():
-    """Test the create_input_file method with an alternate name."""
-    d.create_input_file(alt_input_file)
-    assert_true(os.path.exists(alt_input_file))
+def test_create_input_file_with_method_default_name():
+    """Test create_input_file works when instanced with method."""
+    d = Dakota(method='vector_parameter_study')
+    d.create_input_file()
+    assert_true(os.path.exists(d.input_file))
+
+def test_create_input_file_with_method_new_name():
+    """Test create_input_file works when instanced with method and new name."""
+    d = Dakota(method='vector_parameter_study')
+    d.create_input_file(input_file=alt_input_file)
+    assert_true(os.path.exists(d.input_file))
 
 def test_input_file_contents():
-    """Test create_input_file method results versus a known input file."""
+    """Test create_input_file results versus a known input file."""
+    d = Dakota(method='vector_parameter_study')
     d.create_input_file()
     assert_true(filecmp.cmp(known_file, input_file))
 
-def test_run():
-    """Test the run method."""
-    print(d.method, d.analysis_driver)
-    if not os.path.exists(d.input_file):
-        d.create_input_file('test.in')
+def test_run_with_input_file():
+    """Test run method with an input file."""
+    if is_dakota_installed is False: return
+    d = Dakota(input_file=known_file)
     d.run()
     assert_true(os.path.exists(d.input_file))
     assert_true(os.path.exists(d.output_file))
-    assert_true(os.path.exists(d.data_file))
+    assert_true(os.path.exists(data_file))
+
+@raises(IOError)
+def test_run_without_input_file1():
+    """Test run method fails without an input file."""
+    if is_dakota_installed is False: return
+    d = Dakota(input_file='xyz.in')
+    d.run()
+
+@raises(IOError)
+def test_run_without_input_file2():
+    """Test run method fails with method parameter."""
+    if is_dakota_installed is False: return
+    if os.path.exists(input_file): os.remove(input_file)
+    d = Dakota(method='vector_parameter_study')
+    d.run()

--- a/dakota/tests/test_dakota.py
+++ b/dakota/tests/test_dakota.py
@@ -11,10 +11,9 @@ import os
 import filecmp
 from nose.tools import *
 from dakota.dakota import Dakota
+from . import start_dir, data_dir
 
 # Global variables
-start_dir = os.getcwd()
-data_dir = os.path.join(start_dir, 'dakota', 'tests', 'data')
 input_file = 'dakota.in'
 alt_input_file = 'alt.in'
 known_file = os.path.join(data_dir, 'dakota.in')

--- a/dakota/tests/test_dakota.py
+++ b/dakota/tests/test_dakota.py
@@ -10,8 +10,7 @@
 import os
 import filecmp
 from nose.tools import *
-from dakota.dakota import is_dakota_installed, Dakota, get_labels, \
-    get_analysis_components
+from dakota.dakota import Dakota
 
 # Global variables
 start_dir = os.getcwd()
@@ -19,11 +18,6 @@ data_dir = os.path.join(start_dir, 'dakota', 'tests', 'data')
 input_file = 'dakota.in'
 alt_input_file = 'alt.in'
 known_file = os.path.join(data_dir, 'dakota.in')
-parameters_file = os.path.join(data_dir, 'vector_parameter_study_params.in')
-response_labels = ['Qs_median']
-model = 'hydrotrend'
-output_file = 'HYDROASCII.QS'
-response_statistic = 'median'
 
 # Fixtures -------------------------------------------------------------
 
@@ -48,10 +42,6 @@ def teardown_module():
 
 # Tests ----------------------------------------------------------------
 
-def test_is_dakota_installed():
-    """Test whether Dakota is installed."""
-    assert_true(is_dakota_installed)
-
 def test_constructor_alt_input_file():
     """Test calling the constructor with an input file."""
     d1 = Dakota(alt_input_file)
@@ -71,51 +61,6 @@ def test_input_file_contents():
     """Test create_input_file method results versus a known input file."""
     d.create_input_file()
     assert_true(filecmp.cmp(known_file, input_file))
-
-def test_environment_block():
-    """Test type of environment_block method results."""
-    s = d.environment_block()
-    assert_true(type(s) is str)
-
-def test_method_block():
-    """Test type of method_block method results."""
-    s = d.method_block()
-    assert_true(type(s) is str)
-
-def test_variables_block():
-    """Test type of variables_block method results."""
-    s = d.variables_block()
-    assert_true(type(s) is str)
-
-def test_interface_block():
-    """Test type of interface_block method results."""
-    s = d.interface_block()
-    assert_true(type(s) is str)
-
-def test_responses_block():
-    """Test type of responses_block method results."""
-    s = d.responses_block()
-    assert_true(type(s) is str)
-
-def test_get_labels():
-    """Test the get_labels function."""
-    assert_equal(response_labels, get_labels(parameters_file))
-
-def test_get_labels_unknown_file():
-    """Test get_labels when parameters file not found."""
-    assert_is_none(get_labels('foo.in'))
-
-def test_get_analysis_components():
-    """Test the get_analysis_components function."""
-    ac = get_analysis_components(parameters_file)
-    assert_equal(model, ac.pop(0))
-    response = ac.pop(0)
-    assert_equal(response['file'], output_file)
-    assert_equal(response['statistic'], response_statistic)
-
-def test_get_analysis_components_unknown_file():
-    """Test get_analysis_components when parameters file not found."""
-    assert_is_none(get_analysis_components('foo.in'))
 
 def test_run():
     """Test the run method."""

--- a/dakota/tests/test_dakota_base.py
+++ b/dakota/tests/test_dakota_base.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+#
+# Tests for dakota.dakota_base module.
+#
+# Call with:
+#   $ nosetests -sv
+#
+# Mark Piper (mark.piper@colorado.edu)
+
+import os
+import filecmp
+from nose.tools import *
+from dakota.dakota_base import DakotaBase
+
+
+# Fixtures -------------------------------------------------------------
+
+def setup_module():
+    """Called before any tests are performed."""
+    print('\n*** DakotaBase tests')
+
+def teardown_module():
+    """Called after all tests have completed."""
+    pass
+
+# Tests ----------------------------------------------------------------
+
+@raises(TypeError)
+def test_instantiate():
+    """Test whether DakotaBase fails to instantiate."""
+    d = DakotaBase()

--- a/dakota/tests/test_dakota_base.py
+++ b/dakota/tests/test_dakota_base.py
@@ -9,6 +9,7 @@
 
 from nose.tools import *
 from dakota.dakota_base import DakotaBase
+from . import start_dir, data_dir
 
 # Helpers --------------------------------------------------------------
 

--- a/dakota/tests/test_dakota_base.py
+++ b/dakota/tests/test_dakota_base.py
@@ -7,17 +7,23 @@
 #
 # Mark Piper (mark.piper@colorado.edu)
 
-import os
-import filecmp
 from nose.tools import *
 from dakota.dakota_base import DakotaBase
 
+# Helpers --------------------------------------------------------------
+
+class Concrete(DakotaBase):
+    """A subclass of DakotaBase used for testing."""
+    def __init__(self):
+        DakotaBase.__init__(self)
 
 # Fixtures -------------------------------------------------------------
 
 def setup_module():
     """Called before any tests are performed."""
     print('\n*** DakotaBase tests')
+    global c
+    c = Concrete()
 
 def teardown_module():
     """Called after all tests have completed."""
@@ -29,3 +35,35 @@ def teardown_module():
 def test_instantiate():
     """Test whether DakotaBase fails to instantiate."""
     d = DakotaBase()
+
+def test_environment_block():
+    """Test type of environment_block method results."""
+    s = c.environment_block()
+    assert_true(type(s) is str)
+
+def test_method_block():
+    """Test type of method_block method results."""
+    s = c.method_block()
+    assert_true(type(s) is str)
+
+def test_variables_block():
+    """Test type of variables_block method results."""
+    s = c.variables_block()
+    assert_true(type(s) is str)
+
+def test_interface_block():
+    """Test type of interface_block method results."""
+    s = c.interface_block()
+    assert_true(type(s) is str)
+
+def test_responses_block():
+    """Test type of responses_block method results."""
+    s = c.responses_block()
+    assert_true(type(s) is str)
+
+def test_autogenerate_descriptors():
+    """Test autogenerate_descriptors method."""
+    c.n_variables, c.n_responses = 1, 1
+    c.autogenerate_descriptors()
+    assert_true(len(c.variable_descriptors) == 1)
+    assert_true(len(c.response_descriptors) == 1)

--- a/dakota/tests/test_dakota_base.py
+++ b/dakota/tests/test_dakota_base.py
@@ -22,7 +22,7 @@ class Concrete(DakotaBase):
 
 def setup_module():
     """Called before any tests are performed."""
-    print('\n*** DakotaBase tests')
+    print('\n*** ' + __name__)
     global c
     c = Concrete()
 

--- a/dakota/tests/test_dakota_base.py
+++ b/dakota/tests/test_dakota_base.py
@@ -62,9 +62,9 @@ def test_responses_block():
     s = c.responses_block()
     assert_true(type(s) is str)
 
-def test_autogenerate_descriptors():
-    """Test autogenerate_descriptors method."""
+def test_generate_descriptors():
+    """Test generate_descriptors method."""
     c.n_variables, c.n_responses = 1, 1
-    c.autogenerate_descriptors()
+    c.generate_descriptors()
     assert_true(len(c.variable_descriptors) == 1)
     assert_true(len(c.response_descriptors) == 1)

--- a/dakota/tests/test_dakota_utils.py
+++ b/dakota/tests/test_dakota_utils.py
@@ -20,6 +20,16 @@ model = 'hydrotrend'
 output_file = 'HYDROASCII.QS'
 response_statistic = 'median'
 
+# Fixtures -------------------------------------------------------------
+
+def setup_module():
+    """Called before any tests are performed."""
+    print('\n*** dakota_utils tests')
+
+def teardown_module():
+    """Called after all tests have completed."""
+    pass
+
 # Tests ----------------------------------------------------------------
 
 def test_is_dakota_installed():

--- a/dakota/tests/test_dakota_utils.py
+++ b/dakota/tests/test_dakota_utils.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#
+# Tests for dakota.dakota_utils module.
+#
+# Call with:
+#   $ nosetests -sv
+#
+# Mark Piper (mark.piper@colorado.edu)
+
+import os
+from nose.tools import *
+from dakota.dakota_utils import *
+
+# Global variables
+start_dir = os.getcwd()
+data_dir = os.path.join(start_dir, 'dakota', 'tests', 'data')
+parameters_file = os.path.join(data_dir, 'vector_parameter_study_params.in')
+response_labels = ['Qs_median']
+model = 'hydrotrend'
+output_file = 'HYDROASCII.QS'
+response_statistic = 'median'
+
+# Tests ----------------------------------------------------------------
+
+def test_is_dakota_installed():
+    """Test whether Dakota is installed."""
+    assert_true(is_dakota_installed())
+
+def test_get_response_descriptors():
+    """Test the get_response_descriptors function."""
+    assert_equal(response_labels, get_response_descriptors(parameters_file))
+
+def test_get_response_descriptors_unknown_file():
+    """Test get_response_descriptors when parameters file not found."""
+    assert_is_none(get_response_descriptors('foo.in'))
+
+def test_get_analysis_components():
+    """Test the get_analysis_components function."""
+    ac = get_analysis_components(parameters_file)
+    assert_equal(model, ac.pop(0))
+    response = ac.pop(0)
+    assert_equal(response['file'], output_file)
+    assert_equal(response['statistic'], response_statistic)
+
+def test_get_analysis_components_unknown_file():
+    """Test get_analysis_components when parameters file not found."""
+    assert_is_none(get_analysis_components('foo.in'))

--- a/dakota/tests/test_dakota_utils.py
+++ b/dakota/tests/test_dakota_utils.py
@@ -23,7 +23,7 @@ response_statistic = 'median'
 
 def setup_module():
     """Called before any tests are performed."""
-    print('\n*** dakota_utils tests')
+    print('\n*** ' + __name__)
 
 def teardown_module():
     """Called after all tests have completed."""

--- a/dakota/tests/test_dakota_utils.py
+++ b/dakota/tests/test_dakota_utils.py
@@ -10,10 +10,9 @@
 import os
 from nose.tools import *
 from dakota.dakota_utils import *
+from . import start_dir, data_dir
 
 # Global variables
-start_dir = os.getcwd()
-data_dir = os.path.join(start_dir, 'dakota', 'tests', 'data')
 parameters_file = os.path.join(data_dir, 'vector_parameter_study_params.in')
 response_labels = ['Qs_median']
 model = 'hydrotrend'

--- a/dakota/tests/test_vector_parameter_study.py
+++ b/dakota/tests/test_vector_parameter_study.py
@@ -16,7 +16,7 @@ from . import start_dir, data_dir
 
 def setup_module():
     """Called before any tests are performed."""
-    print('\n*** VectorParameterStudy tests')
+    print('\n*** ' + __name__)
     global v
     v = VectorParameterStudy()
 

--- a/dakota/tests/test_vector_parameter_study.py
+++ b/dakota/tests/test_vector_parameter_study.py
@@ -9,6 +9,7 @@
 
 from nose.tools import *
 from dakota.vector_parameter_study import VectorParameterStudy, method
+from . import start_dir, data_dir
 
 
 # Fixtures -------------------------------------------------------------

--- a/dakota/tests/test_vector_parameter_study.py
+++ b/dakota/tests/test_vector_parameter_study.py
@@ -7,17 +7,9 @@
 #
 # Mark Piper (mark.piper@colorado.edu)
 
-import os
-import filecmp
 from nose.tools import *
-from dakota.vector_parameter_study import VectorParameterStudy
+from dakota.vector_parameter_study import VectorParameterStudy, method
 
-# Global variables
-start_dir = os.getcwd()
-data_dir = os.path.join(start_dir, 'dakota', 'tests', 'data')
-input_file = 'dakota.in'
-alt_input_file = 'alt.in'
-known_file = os.path.join(data_dir, 'vector_parameter_study.in')
 
 # Fixtures -------------------------------------------------------------
 
@@ -29,74 +21,20 @@ def setup_module():
 
 def teardown_module():
     """Called after all tests have completed."""
-    if os.path.exists(input_file):
-        os.remove(input_file)
-    if os.path.exists(alt_input_file):
-        os.remove(alt_input_file)
-    if os.path.exists(v.output_file):
-        os.remove(v.output_file)
-    if os.path.exists(v.data_file):
-        os.remove(v.data_file)
-    if os.path.exists('dakota.rst'):
-        os.remove('dakota.rst')
-
-def setup():
-    """Called at start of any test using it @with_setup()"""
-    global w
-    w = VectorParameterStudy()
-    w.model = 'hydrotrend'
-    w.input_file = input_file
-    w.variable_descriptors = ['T', 'P']
-    w.n_variables = len(w.variable_descriptors)
-    w.initial_point = [10.0, 1.5]
-    w.final_point = [20.0, 2.5]
-    w.n_steps = 6
-    w.interface = 'fork'
-    w.analysis_driver = 'run_model.py'
-    w.response_descriptors = ['Qs_median', 'Q_mean']
-    w.n_responses = len(w.response_descriptors)
-    w.response_files = ['HYDROASCII.QS', 'HYDROASCII.Q']
-    w.response_statistics = ['median', 'mean']
-
-def teardown():
-    """Called at end of any test using it @with_setup()"""
     pass
 
 # Tests ----------------------------------------------------------------
 
-def test_constructor_alt_input_file():
-    """Test calling the constructor with an input file."""
-    v1 = VectorParameterStudy(alt_input_file)
-    assert_equal(v1.input_file, alt_input_file)
+def test_method_function():
+    """Test the method helper function."""
+    assert_equal(v.__class__, method().__class__)
 
-def test_create_default_input_file():
-    """Test the create_input_file method with default parameters."""
-    v.create_input_file()
-    assert_true(os.path.exists(input_file))
+def test_method_block():
+    """Test type of method_block method results."""
+    s = v.method_block()
+    assert_true(type(s) is str)
 
-def test_create_alt_input_file():
-    """Test the create_input_file method with an alternate name."""
-    v.create_input_file(alt_input_file)
-    assert_true(os.path.exists(alt_input_file))
-
-@with_setup(setup, teardown)
-def test_create_input_file():
-    """Test the create_input_file method with experiment parameters."""
-    w.create_input_file()
-    assert_true(os.path.exists(input_file))
-
-@with_setup(setup, teardown)
-def test_input_file_contents():
-    """Test create_input_file method results versus a known input file."""
-    w.create_input_file()
-    assert_true(filecmp.cmp(known_file, input_file))
-
-def test_run():
-    """Test the run method."""
-    print(v.method, v.analysis_driver)
-    if not os.path.exists(v.input_file):
-        v.create_input_file('test.in')
-    v.run()
-    assert_true(os.path.exists(v.input_file))
-    assert_true(os.path.exists(v.output_file))
-    assert_true(os.path.exists(v.data_file))
+def test_variables_block():
+    """Test type of variables_block method results."""
+    s = v.variables_block()
+    assert_true(type(s) is str)

--- a/dakota/vector_parameter_study.py
+++ b/dakota/vector_parameter_study.py
@@ -1,24 +1,47 @@
 #! /usr/bin/env python
 """Implementation of a Dakota vector parameter study."""
 
-from .dakota import Dakota
+from .dakota_base import DakotaBase
 
 
-class VectorParameterStudy(Dakota):
-    """Set up a Dakota vector parameter study."""
+def method():
+    """A helper function to return a VectorParameterStudy object.
 
-    def __init__(self, input_file='dakota.in'):
+    Returns
+    -------
+    object
+      An instance of VectorParameterStudy.
+
+    Examples
+    --------
+    Call this function instead of the class constructor to obtain a
+    VectorParameterStudy instance.
+
+    >>> import dakota.vector_parameter_study as m
+    >>> v = m.model() # instead of v = m.VectorParameterStudy()
+    """
+    return VectorParameterStudy()
+
+class VectorParameterStudy(DakotaBase):
+    """Define parameters for a Dakota vector parameter study."""
+
+    def __init__(self):
         """Create a new Dakota vector parameter study."""
-        Dakota.__init__(self, input_file)
+        DakotaBase.__init__(self)
         self.method = 'vector_parameter_study'
         self.initial_point = [-0.3, 0.2]
         self.final_point = [1.1, 1.3]
         self.n_steps = 10
+        self.n_variables = len(self.initial_point)
         self.interface = 'direct'
         self.analysis_driver = 'rosenbrock'
+        self.n_responses = 1
+        self.autogenerate_descriptors()
 
     def method_block(self):
-        """Define the method block of a Dakota input file."""
+        """Define the method block of a Dakota input file for a vector
+        parameter study.
+        """
         s = 'method\n' \
             + '  {}\n'.format(self.method) \
             + '    final_point ='
@@ -29,7 +52,9 @@ class VectorParameterStudy(Dakota):
         return(s)
 
     def variables_block(self):
-        """Define the variables block of a Dakota input file."""
+        """Define the variables block of a Dakota input file for a vector
+        parameter study.
+        """
         s = 'variables\n' \
             + '  {0} = {1}\n'.format(self.variable_type, self.n_variables) \
             + '    initial_point ='

--- a/dakota/vector_parameter_study.py
+++ b/dakota/vector_parameter_study.py
@@ -5,7 +5,12 @@ from .dakota_base import DakotaBase
 
 
 def method():
-    """A helper function to return a VectorParameterStudy object.
+    """Call this helper function to create a VectorParameterStudy object.
+
+    Every subclass of DakotaBase implements a **method** function to
+    return an instance of the class stored in the module. This way,
+    only the module name (which matches the Dakota ``method`` keyword)
+    is needed to create an instance of the subclass.
 
     Returns
     -------
@@ -15,10 +20,11 @@ def method():
     Examples
     --------
     Call this function instead of the class constructor to obtain a
-    VectorParameterStudy instance.
+    VectorParameterStudy instance:
 
     >>> import dakota.vector_parameter_study as m
     >>> v = m.method() # instead of v = m.VectorParameterStudy()
+
     """
     return VectorParameterStudy()
 

--- a/dakota/vector_parameter_study.py
+++ b/dakota/vector_parameter_study.py
@@ -18,7 +18,7 @@ def method():
     VectorParameterStudy instance.
 
     >>> import dakota.vector_parameter_study as m
-    >>> v = m.model() # instead of v = m.VectorParameterStudy()
+    >>> v = m.method() # instead of v = m.VectorParameterStudy()
     """
     return VectorParameterStudy()
 

--- a/dakota/vector_parameter_study.py
+++ b/dakota/vector_parameter_study.py
@@ -42,7 +42,7 @@ class VectorParameterStudy(DakotaBase):
         self.interface = 'direct'
         self.analysis_driver = 'rosenbrock'
         self.n_responses = 1
-        self.autogenerate_descriptors()
+        self.generate_descriptors()
 
     def method_block(self):
         """Define the method block of a Dakota input file for a vector


### PR DESCRIPTION
There's now a single interface for running a Dakota experiment.

If the user has a Dakota input file, they can load it and run the experiment with:

```
d = Dakota(input_file='/path/to/dakota.in')
d.run()
```

To configure and run a new experiment:

```
d = Dakota(method='dakota_method_keyword')
...
d.create_input_file()
d.run()
```

where `dakota_method_keyword` is the name of a Python module containing a class that implements the requested iterative method in Dakota.

One of `input_file` or `method` parameters must be selected, and they are mutually exclusive.
