### PR TITLE
Convert multi-item attributes to properties

### DIFF
--- a/dakota/core.py
+++ b/dakota/core.py
@@ -90,8 +90,13 @@ class Dakota(object):
         """
         if config_file is not None:
             self.method.configuration_file = config_file
+        props = self.method.__dict__.copy()
+        for key in props:
+            if key.startswith('_'):
+                new_key = key.lstrip('_')
+                props[new_key] = props.pop(key)
         with open(self.method.configuration_file, 'w') as fp:
-            yaml.dump(self.method.__dict__, fp, default_flow_style=False)
+            yaml.dump(props, fp, default_flow_style=False)
 
     def write_input_file(self, input_file=None):
         """Create a Dakota input file on the file system.

--- a/dakota/methods/base.py
+++ b/dakota/methods/base.py
@@ -2,6 +2,7 @@
 """An abstract base class for all Dakota experiments."""
 
 from abc import ABCMeta, abstractmethod
+import os
 import types
 import yaml
 
@@ -15,10 +16,10 @@ class DakotaBase(object):
     @abstractmethod
     def __init__(self,
                  component=None,
-                 template_file=None,
                  method=None,
-                 configuration_file='config.yaml',
-                 run_directory='.',
+                 configuration_file=os.path.abspath('config.yaml'),
+                 run_directory=os.getcwd(),
+                 template_file=None,
                  input_files=(),
                  data_file='dakota.dat',
                  variable_type='continuous_design',
@@ -32,8 +33,8 @@ class DakotaBase(object):
                  **kwargs):
         """Create a set of default experiment parameters."""
         self.component = component
-        self.configuration_file = configuration_file
-        self.run_directory = run_directory
+        self._run_directory = run_directory
+        self._configuration_file = configuration_file
         self.template_file = template_file
         self.input_files = input_files
         self.data_file = data_file
@@ -48,6 +49,44 @@ class DakotaBase(object):
         self._response_descriptors = response_descriptors
         self._response_files = response_files
         self._response_statistics = response_statistics
+
+    @property
+    def run_directory(self):
+        """The run directory path."""
+        return self._run_directory
+
+    @run_directory.setter
+    def run_directory(self, value):
+        """Set the run directory path.
+
+        Parameters
+        ----------
+        value : str
+          The new run directory path.
+
+        """
+        if not os.path.isabs(value):
+            value = os.path.abspath(value)
+        self._run_directory = value
+
+    @property
+    def configuration_file(self):
+        """The configuration file path."""
+        return self._configuration_file
+
+    @configuration_file.setter
+    def configuration_file(self, value):
+        """Set the configuration file path.
+
+        Parameters
+        ----------
+        value : str
+          The new file path.
+
+        """
+        if not os.path.isabs(value):
+            value = os.path.abspath(value)
+        self._configuration_file = value
 
     @property
     def input_files(self):

--- a/dakota/methods/base.py
+++ b/dakota/methods/base.py
@@ -27,8 +27,8 @@ class DakotaBase(object):
                  analysis_driver='rosenbrock',
                  is_objective_function=False,
                  response_descriptors=(),
-                 response_files=None,
-                 response_statistics=None,
+                 response_files=(),
+                 response_statistics=(),
                  **kwargs):
         """Create a set of default experiment parameters."""
         self.component = component
@@ -46,8 +46,8 @@ class DakotaBase(object):
         self.results_file = 'results.out'
         self.is_objective_function = is_objective_function
         self._response_descriptors = response_descriptors
-        self.response_files = response_files
-        self.response_statistics = response_statistics
+        self._response_files = response_files
+        self._response_statistics = response_statistics
 
     @property
     def variable_descriptors(self):
@@ -86,6 +86,44 @@ class DakotaBase(object):
         if not isinstance(value, (tuple, list)):
             raise TypeError("Descriptor must be a tuple or a list")
         self._response_descriptors = value
+
+    @property
+    def response_files(self):
+        """Model output files used in Dakota responses."""
+        return self._response_files
+
+    @response_files.setter
+    def response_files(self, value):
+        """Set model output files for Dakota responses.
+
+        Parameters
+        ----------
+        value : list or tuple of str
+          The new response files.
+
+        """
+        if not isinstance(value, (tuple, list)):
+            raise TypeError("Response files must be a tuple or a list")
+        self._response_files = value
+
+    @property
+    def response_statistics(self):
+        """Model output statistics used in Dakota responses."""
+        return self._response_statistics
+
+    @response_statistics.setter
+    def response_statistics(self, value):
+        """Set model output statistics for Dakota responses.
+
+        Parameters
+        ----------
+        value : list or tuple of str
+          The new response statistics.
+
+        """
+        if not isinstance(value, (tuple, list)):
+            raise TypeError("Response statistics must be a tuple or a list")
+        self._response_statistics = value
 
     @classmethod
     def from_file_like(cls, file_like):

--- a/dakota/methods/base.py
+++ b/dakota/methods/base.py
@@ -22,7 +22,7 @@ class DakotaBase(object):
                  input_files=None,
                  data_file='dakota.dat',
                  variable_type='continuous_design',
-                 variable_descriptors=None,
+                 variable_descriptors=(),
                  interface='direct',
                  analysis_driver='rosenbrock',
                  is_objective_function=False,
@@ -39,8 +39,7 @@ class DakotaBase(object):
         self.data_file = data_file
         self.method = method
         self.variable_type = variable_type
-        self.variable_descriptors = [] if variable_descriptors is None \
-                                    else variable_descriptors
+        self._variable_descriptors = variable_descriptors
         self.interface = interface
         self.analysis_driver = analysis_driver
         self.parameters_file = 'params.in'
@@ -49,6 +48,25 @@ class DakotaBase(object):
         self._response_descriptors = response_descriptors
         self.response_files = response_files
         self.response_statistics = response_statistics
+
+    @property
+    def variable_descriptors(self):
+        """Labels attached to Dakota variables."""
+        return self._variable_descriptors
+
+    @variable_descriptors.setter
+    def variable_descriptors(self, value):
+        """Set labels for Dakota variables.
+
+        Parameters
+        ----------
+        value : list or tuple of str
+          The new variables labels.
+
+        """
+        if not isinstance(value, (tuple, list)):
+            raise TypeError("Descriptor must be a tuple or a list")
+        self._variable_descriptors = value
 
     @property
     def response_descriptors(self):

--- a/dakota/methods/base.py
+++ b/dakota/methods/base.py
@@ -13,15 +13,23 @@ class DakotaBase(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def __init__(self, component=None, template_file=None,
-                 method=None, configuration_file='config.yaml',
-                 run_directory='.', input_files=None,
+    def __init__(self,
+                 component=None,
+                 template_file=None,
+                 method=None,
+                 configuration_file='config.yaml',
+                 run_directory='.',
+                 input_files=None,
                  data_file='dakota.dat',
                  variable_type='continuous_design',
-                 variable_descriptors=None, interface='direct',
+                 variable_descriptors=None,
+                 interface='direct',
                  analysis_driver='rosenbrock',
-                 is_objective_function=False, response_descriptors=None,
-                 response_files=None, response_statistics=None, **kwargs):
+                 is_objective_function=False,
+                 response_descriptors=(),
+                 response_files=None,
+                 response_statistics=None,
+                 **kwargs):
         """Create a set of default experiment parameters."""
         self.component = component
         self.configuration_file = configuration_file
@@ -38,10 +46,28 @@ class DakotaBase(object):
         self.parameters_file = 'params.in'
         self.results_file = 'results.out'
         self.is_objective_function = is_objective_function
-        self.response_descriptors = [] if response_descriptors is None \
-                                    else response_descriptors
+        self._response_descriptors = response_descriptors
         self.response_files = response_files
         self.response_statistics = response_statistics
+
+    @property
+    def response_descriptors(self):
+        """Labels attached to Dakota responses."""
+        return self._response_descriptors
+
+    @response_descriptors.setter
+    def response_descriptors(self, value):
+        """Set labels for Dakota responses.
+
+        Parameters
+        ----------
+        value : list or tuple of str
+          The new response labels.
+
+        """
+        if not isinstance(value, (tuple, list)):
+            raise TypeError("Descriptor must be a tuple or a list")
+        self._response_descriptors = value
 
     @classmethod
     def from_file_like(cls, file_like):

--- a/dakota/methods/base.py
+++ b/dakota/methods/base.py
@@ -19,7 +19,7 @@ class DakotaBase(object):
                  method=None,
                  configuration_file='config.yaml',
                  run_directory='.',
-                 input_files=None,
+                 input_files=(),
                  data_file='dakota.dat',
                  variable_type='continuous_design',
                  variable_descriptors=(),
@@ -48,6 +48,25 @@ class DakotaBase(object):
         self._response_descriptors = response_descriptors
         self._response_files = response_files
         self._response_statistics = response_statistics
+
+    @property
+    def input_files(self):
+        """Input files used by component."""
+        return self._input_files
+
+    @input_files.setter
+    def input_files(self, value):
+        """Set input files used by component.
+
+        Parameters
+        ----------
+        value : list or tuple of str
+          The new input files.
+
+        """
+        if not isinstance(value, (tuple, list)):
+            raise TypeError("Input files must be a tuple or a list")
+        self._input_files = value
 
     @property
     def variable_descriptors(self):

--- a/dakota/methods/vector_parameter_study.py
+++ b/dakota/methods/vector_parameter_study.py
@@ -11,17 +11,59 @@ class VectorParameterStudy(DakotaBase):
 
     """Define parameters for a Dakota vector parameter study."""
 
-    def __init__(self, variable_descriptors=('x1', 'x2'),
-                 initial_point=(-0.3, 0.2), final_point=(1.1, 1.3), n_steps=10,
-                 response_descriptors=('y1',), **kwargs):
+    def __init__(self,
+                 variable_descriptors=('x1', 'x2'),
+                 initial_point=(-0.3, 0.2),
+                 final_point=(1.1, 1.3),
+                 n_steps=10,
+                 response_descriptors=('y1',),
+                 **kwargs):
         """Create a new Dakota vector parameter study."""
         DakotaBase.__init__(self, **kwargs)
         self.method = 'vector_parameter_study'
         self.variable_descriptors = variable_descriptors
-        self.initial_point = initial_point
-        self.final_point = final_point
+        self._initial_point = initial_point
+        self._final_point = final_point
         self.n_steps = n_steps
         self.response_descriptors = response_descriptors
+
+    @property
+    def initial_point(self):
+        """Start points used by study variables."""
+        return self._initial_point
+
+    @initial_point.setter
+    def initial_point(self, value):
+        """Set start points used by study variables.
+
+        Parameters
+        ----------
+        value : list or tuple of numbers
+          The new initial points.
+
+        """
+        if not isinstance(value, (tuple, list)):
+            raise TypeError("Initial points must be a tuple or a list")
+        self._initial_point = value
+
+    @property
+    def final_point(self):
+        """End points used by study variables."""
+        return self._final_point
+
+    @final_point.setter
+    def final_point(self, value):
+        """Set end points used by study variables.
+
+        Parameters
+        ----------
+        value : list or tuple of numbers
+          The new final points.
+
+        """
+        if not isinstance(value, (tuple, list)):
+            raise TypeError("Final points must be a tuple or a list")
+        self._final_point = value
 
     def method_block(self):
         """Define a vector parameter study method block for a Dakota input file.

--- a/dakota/plugins/hydrotrend.py
+++ b/dakota/plugins/hydrotrend.py
@@ -75,7 +75,7 @@ class HydroTrend(PluginBase):
 
         """
         self.input_template = config['template_file']
-        self.hypsometry_file = config['input_files'][0]
+        self.hypsometry_file, = config['input_files']
         self.output_files = config['response_files']
         self.output_statistics = config['response_statistics']
 

--- a/dakota/tests/test_dakota_base.py
+++ b/dakota/tests/test_dakota_base.py
@@ -80,6 +80,63 @@ def test_set_input_files_fails_if_scalar():
     c.input_files = input_file
 
 
+def test_get_response_descriptors():
+    """Test getting the response_descriptors property."""
+    assert_equal(c.response_descriptors, tuple())
+
+
+def test_set_response_descriptors():
+    """Test setting the response_descriptors property."""
+    desc = ['Qs_median']
+    c.response_descriptors = desc
+    assert_equal(c.response_descriptors, desc)
+
+
+@raises(TypeError)
+def test_set_response_descriptors_fails_if_scalar():
+    """Test that the response_descriptors property fails with scalar string."""
+    desc = 'Qs_median'
+    c.response_descriptors = desc
+
+
+def test_get_response_files():
+    """Test getting the response_files property."""
+    assert_equal(c.response_files, tuple())
+
+
+def test_set_response_files():
+    """Test setting the response_files property."""
+    files = ['HYDROASCII.QS']
+    c.response_files = files
+    assert_equal(c.response_files, files)
+
+
+@raises(TypeError)
+def test_set_response_files_fails_if_scalar():
+    """Test that the response_files property fails with scalar string."""
+    files = 'HYDROASCII.QS'
+    c.response_files = files
+
+
+def test_get_response_statistics():
+    """Test getting the response_statistics property."""
+    assert_equal(c.response_statistics, tuple())
+
+
+def test_set_response_statistics():
+    """Test setting the response_statistics property."""
+    stats = ['median']
+    c.response_statistics = stats
+    assert_equal(c.response_statistics, stats)
+
+
+@raises(TypeError)
+def test_set_response_statistics_fails_if_scalar():
+    """Test that the response_statistics property fails with scalar string."""
+    stats = 'median'
+    c.response_statistics = stats
+
+
 def test_environment_block():
     """Test type of environment_block method results."""
     s = c.environment_block()
@@ -106,5 +163,12 @@ def test_interface_block():
 
 def test_responses_block():
     """Test type of responses_block method results."""
+    s = c.responses_block()
+    assert_true(type(s) is str)
+
+
+def test_responses_block_with_objective_function():
+    """Test type of responses_block method results."""
+    c.is_objective_function = True
     s = c.responses_block()
     assert_true(type(s) is str)

--- a/dakota/tests/test_dakota_base.py
+++ b/dakota/tests/test_dakota_base.py
@@ -7,7 +7,8 @@
 #
 # Mark Piper (mark.piper@colorado.edu)
 
-from nose.tools import raises, assert_true, assert_is_none
+import os
+from nose.tools import raises, assert_true, assert_is_none, assert_equal
 from dakota.methods.base import DakotaBase
 from . import start_dir, data_dir
 
@@ -46,6 +47,37 @@ def teardown_module():
 def test_instantiate():
     """Test whether DakotaBase fails to instantiate."""
     d = DakotaBase()
+
+
+def test_get_run_directory():
+    """Test getting the run_directory property."""
+    assert_equal(c.run_directory, os.getcwd())
+
+
+def test_set_run_directory():
+    """Test setting the run_directory property."""
+    run_dir = '/foo/bar'
+    c.run_directory = run_dir
+    assert_equal(c.run_directory, run_dir)
+
+
+def test_get_input_files():
+    """Test getting the input_files property."""
+    assert_equal(c.input_files, tuple())
+
+
+def test_set_input_files():
+    """Test setting the input_files property."""
+    input_file = ['foo.in']
+    c.input_files = input_file
+    assert_equal(c.input_files, input_file)
+
+
+@raises(TypeError)
+def test_set_input_files_fails_if_scalar():
+    """Test that the input_files property fails with scalar string."""
+    input_file = 'foo.in'
+    c.input_files = input_file
 
 
 def test_environment_block():

--- a/dakota/tests/test_vector_parameter_study.py
+++ b/dakota/tests/test_vector_parameter_study.py
@@ -8,7 +8,7 @@
 # Mark Piper (mark.piper@colorado.edu)
 
 import os
-from nose.tools import assert_is_instance, assert_true
+from nose.tools import raises, assert_is_instance, assert_true, assert_equal
 from dakota.methods.vector_parameter_study import VectorParameterStudy
 from . import start_dir, data_dir
 
@@ -51,6 +51,44 @@ def test_init_from_file_like2():
     with open(config_file, 'r') as fp:
         v1 = VectorParameterStudy.from_file_like(fp)
     assert_is_instance(v1, VectorParameterStudy)
+
+
+def test_get_initial_point():
+    """Test getting the initial_point property."""
+    assert_true(type(v.initial_point) is tuple)
+
+
+def test_set_initial_point():
+    """Test setting the initial_point property."""
+    point = (42,)
+    v.initial_point = point
+    assert_equal(v.initial_point, point)
+
+
+@raises(TypeError)
+def test_set_initial_point_fails_if_scalar():
+    """Test that the initial_point property fails with scalar."""
+    point = 42
+    v.initial_point = point
+
+
+def test_get_final_point():
+    """Test getting the final_point property."""
+    assert_true(type(v.final_point) is tuple)
+
+
+def test_set_final_point():
+    """Test setting the final_point property."""
+    point = (42,)
+    v.final_point = point
+    assert_equal(v.final_point, point)
+
+
+@raises(TypeError)
+def test_set_final_point_fails_if_scalar():
+    """Test that the final_point property fails with scalar."""
+    point = 42
+    v.final_point = point
 
 
 def test_method_block():


### PR DESCRIPTION
This allows me to constrain these attributes to be of type list or tuple.

Also forced `run_directory` and `configuration_file` to use absolute file paths.
