### PR TITLE
Add centered parameter study method

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ specifying the Dakota analysis method:
 	>>> d = Dakota(method='vector_parameter_study')
 
 Currently,
-one Dakota method,
-[vector parameter study](https://dakota.sandia.gov/sites/default/files/docs/6.0/html-ref/method-vector_parameter_study.html),
-is supported.
+two Dakota methods,
+[vector parameter study](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-vector_parameter_study.html)
+and
+[centered parameter study](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-centered_parameter_study.html),
+are supported.
 
 To run a sample case,
 create an input file

--- a/dakota/methods/centered_parameter_study.py
+++ b/dakota/methods/centered_parameter_study.py
@@ -1,0 +1,145 @@
+#! /usr/bin/env python
+"""Implementation of a Dakota centered parameter study."""
+
+from .base import DakotaBase
+
+
+classname = 'CenteredParameterStudy'
+
+
+class CenteredParameterStudy(DakotaBase):
+
+    """Define parameters for a Dakota centered parameter study."""
+
+    def __init__(self,
+                 variable_descriptors=('x1', 'x2'),
+                 initial_point=(0.0, 0.0),
+                 steps_per_variable=(5, 4),
+                 step_vector=(0.4, 0.5),
+                 response_descriptors=('y1',),
+                 **kwargs):
+        """Create a new Dakota centered parameter study.
+
+        Parameters
+        ----------
+        variable_descriptors, response_descriptors : array_like of str
+          Names used for input and output variables.
+        initial_point : array_like of float
+          Start point (the center) for the parameter study.
+        steps_per_variable : array_like of int
+          Number of steps to take in each direction.
+        steps_vector : array_like of float
+          Size of steps in each direction.
+
+        Examples
+        --------
+        Create a default centered parameter study experiment:
+
+        >>> c = CenteredParameterStudy()
+
+        """
+        DakotaBase.__init__(self, **kwargs)
+        self.method = 'centered_parameter_study'
+        self.variable_descriptors = variable_descriptors
+        self._initial_point = initial_point
+        self._steps_per_variable = steps_per_variable
+        self._step_vector = step_vector
+        self.response_descriptors = response_descriptors
+
+    @property
+    def initial_point(self):
+        """Start points used by study variables."""
+        return self._initial_point
+
+    @initial_point.setter
+    def initial_point(self, value):
+        """Set start points used by study variables.
+
+        Parameters
+        ----------
+        value : list or tuple of numbers
+          The new initial points.
+
+        """
+        if not isinstance(value, (tuple, list)):
+            raise TypeError("Initial points must be a tuple or a list")
+        self._initial_point = value
+
+    @property
+    def steps_per_variable(self):
+        """Number of steps to take in each direction."""
+        return self._steps_per_variable
+
+    @steps_per_variable.setter
+    def steps_per_variable(self, value):
+        """Set number of steps to take in each direction.
+
+        Parameters
+        ----------
+        value : list or tuple of int
+          The new number of steps.
+
+        """
+        if not isinstance(value, (tuple, list)):
+            raise TypeError("Steps must be a tuple or a list")
+        self._steps_per_variable = value
+
+    @property
+    def step_vector(self):
+        """Step size in each direction."""
+        return self._step_vector
+
+    @step_vector.setter
+    def step_vector(self, value):
+        """Set step size in each direction.
+
+        Parameters
+        ----------
+        value : list or tuple of int
+          The new step size.
+
+        """
+        if not isinstance(value, (tuple, list)):
+            raise TypeError("Step size must be a tuple or a list")
+        self._step_vector = value
+
+    def method_block(self):
+        """Define a centered parameter study method block.
+
+        See Also
+        --------
+        dakota.methods.base.DakotaBase.method_block
+
+        """
+        s = 'method\n' \
+            + '  {}\n'.format(self.method) \
+            + '    steps_per_variable ='
+        for step in self.steps_per_variable:
+            s += ' {}'.format(step)
+        s += '\n' \
+            + '    step_vector ='
+        for step in self.step_vector:
+            s += ' {}'.format(step)
+        s += '\n\n'
+        return(s)
+
+    def variables_block(self):
+        """Define a centered parameter study variables block.
+
+        See Also
+        --------
+        dakota.methods.base.DakotaBase.variables_block
+
+        """
+        s = 'variables\n' \
+            + '  {0} = {1}\n'.format(self.variable_type,
+                                     len(self.variable_descriptors)) \
+            + '    initial_point ='
+        for pt in self.initial_point:
+            s += ' {}'.format(pt)
+        s += '\n' \
+             + '    descriptors ='
+        for vd in self.variable_descriptors:
+            s += ' {!r}'.format(vd)
+        s += '\n\n'
+        return(s)

--- a/dakota/methods/vector_parameter_study.py
+++ b/dakota/methods/vector_parameter_study.py
@@ -18,7 +18,26 @@ class VectorParameterStudy(DakotaBase):
                  n_steps=10,
                  response_descriptors=('y1',),
                  **kwargs):
-        """Create a new Dakota vector parameter study."""
+        """Create a new Dakota vector parameter study.
+
+        Parameters
+        ----------
+        variable_descriptors, response_descriptors : array_like of str
+          Names used for input and output variables.
+        initial_point : array_like of float
+          Start point for the parameter study.
+        final_point : array_like of float
+          End point for the parameter study.
+        n_steps : int
+          Number of steps along vector.
+
+        Examples
+        --------
+        Create a default vector parameter study experiment:
+
+        >>> v = VectorParameterStudy()
+
+        """
         DakotaBase.__init__(self, **kwargs)
         self.method = 'vector_parameter_study'
         self.variable_descriptors = variable_descriptors

--- a/dakota/tests/data/default_cps_config.yaml
+++ b/dakota/tests/data/default_cps_config.yaml
@@ -1,0 +1,29 @@
+analysis_driver: rosenbrock
+component: null
+configuration_file: /Users/mpiper/scratch/config.yaml
+data_file: dakota.dat
+initial_point: !!python/tuple
+- 0.0
+- 0.0
+input_files: !!python/tuple []
+interface: direct
+is_objective_function: false
+method: centered_parameter_study
+parameters_file: params.in
+response_descriptors: !!python/tuple
+- y1
+response_files: !!python/tuple []
+response_statistics: !!python/tuple []
+results_file: results.out
+run_directory: /Users/mpiper/scratch
+step_vector: !!python/tuple
+- 0.4
+- 0.5
+steps_per_variable: !!python/tuple
+- 5
+- 4
+template_file: null
+variable_descriptors: !!python/tuple
+- x1
+- x2
+variable_type: continuous_design

--- a/dakota/tests/data/default_vps_config.yaml
+++ b/dakota/tests/data/default_vps_config.yaml
@@ -1,0 +1,27 @@
+analysis_driver: rosenbrock
+component: null
+configuration_file: /Users/mpiper/scratch/default_config.yaml
+data_file: dakota.dat
+final_point: !!python/tuple
+- 1.1
+- 1.3
+initial_point: !!python/tuple
+- -0.3
+- 0.2
+input_files: !!python/tuple []
+interface: direct
+is_objective_function: false
+method: vector_parameter_study
+n_steps: 10
+parameters_file: params.in
+response_descriptors: !!python/tuple
+- y1
+response_files: !!python/tuple []
+response_statistics: !!python/tuple []
+results_file: results.out
+run_directory: /Users/mpiper/scratch
+template_file: null
+variable_descriptors: !!python/tuple
+- x1
+- x2
+variable_type: continuous_design

--- a/dakota/tests/test_centered_parameter_study.py
+++ b/dakota/tests/test_centered_parameter_study.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+#
+# Tests for the dakota.centered_parameter_study module.
+#
+# Call with:
+#   $ nosetests -sv
+#
+# Mark Piper (mark.piper@colorado.edu)
+
+import os
+from nose.tools import raises, assert_is_instance, assert_true, assert_equal
+from dakota.methods.centered_parameter_study import CenteredParameterStudy
+from . import start_dir, data_dir
+
+
+# Global variables -----------------------------------------------------
+
+config_file = os.path.join(data_dir, 'default_cps_config.yaml')
+
+# Fixtures -------------------------------------------------------------
+
+
+def setup_module():
+    """Called before any tests are performed."""
+    print('\n*** ' + __name__)
+    global c
+    c = CenteredParameterStudy()
+
+
+def teardown_module():
+    """Called after all tests have completed."""
+    pass
+
+# Tests ----------------------------------------------------------------
+
+
+def test_init_no_params():
+    """Test creating an instance with no parameters."""
+    c1 = CenteredParameterStudy()
+    assert_is_instance(c1, CenteredParameterStudy)
+
+
+def test_init_from_file_like1():
+    """Test creating an instance from a config file."""
+    c1 = CenteredParameterStudy.from_file_like(config_file)
+    assert_is_instance(c1, CenteredParameterStudy)
+
+
+def test_init_from_file_like2():
+    """Test creating an instance from an open config file object."""
+    with open(config_file, 'r') as fp:
+        c1 = CenteredParameterStudy.from_file_like(fp)
+    assert_is_instance(c1, CenteredParameterStudy)
+
+
+def test_get_initial_point():
+    """Test getting the initial_point property."""
+    assert_true(type(c.initial_point) is tuple)
+
+
+def test_set_initial_point():
+    """Test setting the initial_point property."""
+    point = (42, 3.14)
+    c.initial_point = point
+    assert_equal(c.initial_point, point)
+
+
+@raises(TypeError)
+def test_set_initial_point_fails_if_scalar():
+    """Test that the initial_point property fails with scalar."""
+    point = 42
+    c.initial_point = point
+
+
+def test_get_steps_per_variable():
+    """Test getting the steps_per_variable property."""
+    assert_true(type(c.steps_per_variable) is tuple)
+
+
+def test_set_steps_per_variable():
+    """Test setting the steps_per_variable property."""
+    steps = (2, 3)
+    c.steps_per_variable = steps
+    assert_equal(c.steps_per_variable, steps)
+
+
+@raises(TypeError)
+def test_set_steps_per_variable_fails_if_scalar():
+    """Test that the steps_per_variable property fails with scalar."""
+    steps = 2
+    c.steps_per_variable = steps
+
+
+def test_get_step_vector():
+    """Test getting the step_vector property."""
+    assert_true(type(c.step_vector) is tuple)
+
+
+def test_set_step_vector():
+    """Test setting the step_vector property."""
+    steps = (2.0, 3.0)
+    c.step_vector = steps
+    assert_equal(c.step_vector, steps)
+
+
+@raises(TypeError)
+def test_set_step_vector_fails_if_scalar():
+    """Test that the step_vector property fails with scalar."""
+    steps = 2.0
+    c.step_vector = steps
+
+
+def test_method_block():
+    """Test type of method_block method results."""
+    s = c.method_block()
+    assert_true(type(s) is str)
+
+
+def test_variables_block():
+    """Test type of variables_block method results."""
+    s = c.variables_block()
+    assert_true(type(s) is str)

--- a/dakota/tests/test_vector_parameter_study.py
+++ b/dakota/tests/test_vector_parameter_study.py
@@ -15,7 +15,7 @@ from . import start_dir, data_dir
 
 # Global variables -----------------------------------------------------
 
-config_file = os.path.join(data_dir, 'config.yaml')
+config_file = os.path.join(data_dir, 'default_vps_config.yaml')
 
 # Fixtures -------------------------------------------------------------
 


### PR DESCRIPTION
This pull request includes a class, `CenteredParameterStudy`, as well as unit tests, to support the Dakota [centered parameter study](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-centered_parameter_study.html) method.

Unrelated, but included: I modified the tests for the `VectorParameterStudy` class to use the **config.yaml** file produced by the defaults for the class.
