### PR TITLE
Simplify Dakota import

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ build HydroTrend from source:
 
 Import the CSDMS Dakota interface into a Python session with:
 
-	>>> from csdms.dakota.core import Dakota
+	>>> from csdms.dakota import Dakota
 
 Create a `Dakota` instance,
 specifying a Dakota analysis method:

--- a/csdms/dakota/__init__.py
+++ b/csdms/dakota/__init__.py
@@ -1,8 +1,5 @@
 """A Python interface to the Dakota iterative systems analysis toolkit."""
+from .core import Dakota
 
+__all__ = ['Dakota']
 __version__ = '0.2'
-
-methods_path = 'csdms.dakota.methods.'
-plugins_path = 'csdms.dakota.plugins.'
-
-plugin_script = 'dakota_run_plugin'

--- a/csdms/dakota/core.py
+++ b/csdms/dakota/core.py
@@ -6,7 +6,9 @@ import importlib
 import types
 import yaml
 from .methods.vector_parameter_study import VectorParameterStudy
-from . import methods_path
+
+
+_methods_path = 'csdms.dakota.methods.'
 
 
 class Dakota(object):
@@ -42,7 +44,7 @@ class Dakota(object):
         self.output_file = 'dakota.out'
 
         if method is not None:
-            _module = importlib.import_module(methods_path + method)
+            _module = importlib.import_module(_methods_path + method)
             _class = getattr(_module, _module.classname)
             self.method = _class(**kwargs)
         else:

--- a/csdms/dakota/run_plugin.py
+++ b/csdms/dakota/run_plugin.py
@@ -5,8 +5,8 @@ import importlib
 from .utils import get_configuration_file, get_configuration
 
 
+plugin_script = 'dakota_run_plugin'
 _plugins_path = 'csdms.dakota.plugins.'
-_plugin_script = 'dakota_run_plugin'
 
 
 def run_plugin(params_file, results_file):
@@ -78,7 +78,7 @@ def main():
     parser.add_argument("results_file",
                         help="results file to Dakota")
     parser.add_argument('--version', action='version',
-                        version=_plugin_script + ' ' + __version__)
+                        version=plugin_script + ' ' + __version__)
     args = parser.parse_args()
 
     run_plugin(args.parameters_file, args.results_file)

--- a/csdms/dakota/run_plugin.py
+++ b/csdms/dakota/run_plugin.py
@@ -3,7 +3,10 @@
 
 import importlib
 from .utils import get_configuration_file, get_configuration
-from . import plugins_path
+
+
+_plugins_path = 'csdms.dakota.plugins.'
+_plugin_script = 'dakota_run_plugin'
 
 
 def run_plugin(params_file, results_file):
@@ -47,7 +50,7 @@ def run_plugin(params_file, results_file):
     config_file = get_configuration_file(params_file)
     config = get_configuration(config_file)
 
-    _module = importlib.import_module(plugins_path + config['component'])
+    _module = importlib.import_module(_plugins_path + config['component'])
     if _module.is_installed():
         _class = getattr(_module, _module.classname)
         component = _class()
@@ -66,7 +69,7 @@ def run_plugin(params_file, results_file):
 def main():
     """Handle arguments to the `dakota_run_plugin` console script."""
     import argparse
-    from . import __version__, plugin_script
+    from . import __version__
 
     parser = argparse.ArgumentParser(
         description="A generic analysis driver for a Dakota experiment.")
@@ -75,7 +78,7 @@ def main():
     parser.add_argument("results_file",
                         help="results file to Dakota")
     parser.add_argument('--version', action='version',
-                        version=plugin_script + ' ' + __version__)
+                        version=_plugin_script + ' ' + __version__)
     args = parser.parse_args()
 
     run_plugin(args.parameters_file, args.results_file)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,9 @@
 from ez_setup import use_setuptools
 use_setuptools()
 from setuptools import setup, find_packages
-from csdms.dakota import __version__, plugin_script
+from csdms.dakota import __version__
+from csdms.dakota.run_plugin import plugin_script
+
 
 setup(name='csdms-dakota',
       version=__version__,


### PR DESCRIPTION
To import the `Dakota` class, it's now

```
from csdms.dakota import Dakota
```

instead of

```
from csdms.dakota.core import Dakota
```
