### PR TITLE
Usability enhancements

### DIFF
--- a/csdms/dakota/core.py
+++ b/csdms/dakota/core.py
@@ -125,6 +125,21 @@ class Dakota(object):
             fp.write(self.method.interface_block())
             fp.write(self.method.responses_block())
 
+    def setup(self):
+        """Write the Dakota configuration and input files.
+
+        Examples
+        --------
+        As a convenience, make a configuration file and an input file
+        for an experiment in one step:
+
+        >>> d = Dakota(method='vector_parameter_study')
+        >>> d.setup()
+
+        """
+        self.write_configuration_file()
+        self.write_input_file()
+
     def run(self):
         """Run the Dakota experiment."""
         subprocess.check_output(['dakota',

--- a/csdms/dakota/methods/base.py
+++ b/csdms/dakota/methods/base.py
@@ -25,7 +25,7 @@ class MethodsBase(object):
                  variable_type='continuous_design',
                  variable_descriptors=(),
                  interface='direct',
-                 id_interface='Python',
+                 id_interface='CSDMS',
                  analysis_driver='rosenbrock',
                  is_objective_function=False,
                  response_descriptors=(),

--- a/csdms/dakota/methods/base.py
+++ b/csdms/dakota/methods/base.py
@@ -118,7 +118,7 @@ class MethodsBase(object):
 
     @property
     def input_files(self):
-        """Input files used by component."""
+        """A tuple of input files used by the component."""
         return self._input_files
 
     @input_files.setter
@@ -127,13 +127,18 @@ class MethodsBase(object):
 
         Parameters
         ----------
-        value : list or tuple of str
-          The new input files.
+        value : str or list or tuple of str
+          The new input file(s).
 
         """
+        input_files = []
+        if type(value) is str:
+            value = [value]
         if not isinstance(value, (tuple, list)):
-            raise TypeError("Input files must be a tuple or a list")
-        self._input_files = value
+            raise TypeError("Input files must be a string, tuple or list")
+        for item in value:
+            input_files.append(os.path.abspath(item))
+        self._input_files = tuple(input_files)
 
     @property
     def variable_descriptors(self):

--- a/csdms/dakota/methods/base.py
+++ b/csdms/dakota/methods/base.py
@@ -52,6 +52,12 @@ class MethodsBase(object):
         self._response_files = response_files
         self._response_statistics = response_statistics
 
+        if self.component is not None:
+            if self.analysis_driver == 'rosenbrock':
+                self.analysis_driver = 'dakota_run_plugin'
+            if self.interface == 'direct':
+                self.interface = 'fork'
+
     @property
     def run_directory(self):
         """The run directory path."""

--- a/csdms/dakota/tests/data/default_vps_dakota.in
+++ b/csdms/dakota/tests/data/default_vps_dakota.in
@@ -14,7 +14,7 @@ variables
     descriptors = 'x1' 'x2'
 
 interface
-  id_interface = 'Python'
+  id_interface = 'CSDMS'
   direct
   analysis_driver = 'rosenbrock'
 

--- a/csdms/dakota/tests/test_core.py
+++ b/csdms/dakota/tests/test_core.py
@@ -104,6 +104,14 @@ def test_input_file_contents():
     assert_true(filecmp.cmp(known_file, input_file))
 
 
+def test_setup():
+    d = Dakota(method='vector_parameter_study')
+    d.write_configuration_file()
+    d.write_input_file()
+    assert_true(os.path.exists(d.method.configuration_file))
+    assert_true(filecmp.cmp(known_file, input_file))
+
+
 def test_default_run_with_input_file():
     """Test default object run method with input file."""
     if is_dakota_installed():

--- a/csdms/dakota/tests/test_methods_base.py
+++ b/csdms/dakota/tests/test_methods_base.py
@@ -80,15 +80,18 @@ def test_get_input_files():
 
 def test_set_input_files():
     """Test setting the input_files property."""
-    for input_file in [['foo.in'], ('foo.in',)]:
+    for input_file in ['foo.in', ['foo.in'], ('foo.in',)]:
         c.input_files = input_file
-        assert_equal(c.input_files, input_file)
+        if type(input_file) is not str:
+            input_file = input_file[0]
+        pathified_input_file = os.path.abspath(input_file)
+        assert_equal(c.input_files, (pathified_input_file,))
 
 
 @raises(TypeError)
 def test_set_input_files_fails_if_scalar():
-    """Test that the input_files property fails with scalar string."""
-    input_file = 'foo.in'
+    """Test that the input_files property fails with a non-string scalar."""
+    input_file = 42
     c.input_files = input_file
 
 


### PR DESCRIPTION
In this PR, I've made changes that should make it easier to set up and run a Dakota experiment.
- A `setup` method that calls `write_configuration_file` and `write_input_file`
- Set `analysis_driver` and `interface` attributes to appropriate values if a real component is used
- Allow `input_file` property to be a scalar string
