### PR TITLE
Check install process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ os:
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install python-scipy # faster than building with pip
   - pip install -r requirements.txt
   - pip install coveralls
 

--- a/csdms/dakota/__init__.py
+++ b/csdms/dakota/__init__.py
@@ -1,7 +1,6 @@
 """A Python interface to the Dakota iterative systems analysis toolkit."""
 from .dakota import Dakota
-from .bmi_dakota import BmiDakota
 
 
-__all__ = ['Dakota', 'BmiDakota']
+__all__ = ['Dakota']
 __version__ = '0.2'

--- a/csdms/dakota/tests/test_irf.py
+++ b/csdms/dakota/tests/test_irf.py
@@ -2,7 +2,7 @@
 import os
 import yaml
 from nose.tools import assert_is, assert_true, assert_equal, with_setup
-from csdms.dakota import BmiDakota
+from csdms.dakota.bmi_dakota import BmiDakota
 from csdms.dakota.utils import is_dakota_installed
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy
-#scipy
 PyYAML
 nose
-basic-modeling-interface
+basic-modeling-interface>=0.1.3

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 from ez_setup import use_setuptools
 use_setuptools()
 from setuptools import setup, find_packages
@@ -11,7 +10,7 @@ setup(name='csdms-dakota',
       author='Mark Piper',
       author_email='mark.piper@colorado.edu',
       license='MIT',
-      description='Python API for Dakota',
+      description='A Python API for the Dakota systems analysis toolkit',
       long_description=open('README.md').read(),
       install_requires=[
           'numpy',
@@ -19,11 +18,17 @@ setup(name='csdms-dakota',
           'nose',
           'basic-modeling-interface',
       ],
-      namespace_packages=['csdms'], 
+      namespace_packages=['csdms'],
       packages=find_packages(exclude=['*.tests']),
       entry_points={
           'console_scripts': [
               plugin_script + ' = csdms.dakota.run_plugin:main'
           ]
-      }
+      },
+      keywords='CSDMS Dakota uncertainty sensitivity model modeling',
+      classifiers=[
+          'Development Status :: 3 - Alpha',
+          'License :: OSI Approved :: MIT License',
+          'Programming Language :: Python :: 2.7',
+      ],
 )

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,12 @@ setup(name='csdms-dakota',
       license='MIT',
       description='Python API for Dakota',
       long_description=open('README.md').read(),
+      install_requires=[
+          'numpy',
+          'pyyaml',
+          'nose',
+          'basic-modeling-interface',
+      ],
       namespace_packages=['csdms'], 
       packages=find_packages(exclude=['*.tests']),
       entry_points={


### PR DESCRIPTION
I've been working with @sc0tts on packaging Permamodel, so I thought I'd check the install process here. And, oops, it was broken! I was trying to be clever and get version information from the package definition file, but in af066cd7d3afdedc62ace5dc39d7aca54084c2fe, I added an import from `bmi_dakota`, which includes an import from `basic_modeling_interface`, which may not be installed at the point where the version information is used in **setup.py**. So, this motivated the series of minor updates in this PR. 
