### PR TITLE
Fix default multidim parameter study

### DIFF
--- a/csdms/dakota/experiment.py
+++ b/csdms/dakota/experiment.py
@@ -62,6 +62,15 @@ class Experiment(object):
         self.component = component
         if self.component is not None:
             interface = 'fork'
+        if method == 'multidim_parameter_study':
+            try:
+                kwargs['lower_bounds']
+            except KeyError:
+                kwargs['lower_bounds'] = (-2.0, -2.0)
+            try:
+                kwargs['upper_bounds']
+            except KeyError:
+                kwargs['upper_bounds'] = (2.0, 2.0)
         for section in Experiment.blocks:
             cls = self._import(section, eval(section), **kwargs)
             attr = '_' + section

--- a/csdms/dakota/tests/data/default_mps_config.yaml
+++ b/csdms/dakota/tests/data/default_mps_config.yaml
@@ -1,30 +1,38 @@
 analysis_driver: rosenbrock
+asynchronous: false
+auxiliary_files: []
 component: null
-configuration_file: /Users/mpiper/scratch/default_mps_config.yaml
+configuration_file: /Users/mpiper/tmp/config.yaml
+convergence_tolerance: null
 data_file: dakota.dat
-id_interface: Python
-input_files: !!python/tuple []
-interface: direct
-is_objective_function: false
-lower_bounds: !!python/tuple
-- -2.0
-- -2.0
-method: centered_parameter_study
-parameters_file: params.in
-partitions: !!python/tuple
-- 10
-- 8
-responses: !!python/tuple
-- y1
-response_files: !!python/tuple []
-response_statistics: !!python/tuple []
-results_file: results.out
-run_directory: /Users/mpiper/scratch
-template_file: null
-upper_bounds: !!python/tuple
-- 2.0
-- 2.0
-variables: !!python/tuple
+descriptors:
 - x1
 - x2
-variable_type: continuous_design
+evaluation_concurrency: 2
+gradients: no_gradients
+hessians: no_hessians
+id_interface: CSDMS
+initial_point: null
+input_file: dakota.in
+interface: direct
+lower_bounds:
+- -2.0
+- -2.0
+max_iterations: null
+method: multidim_parameter_study
+output_file: dakota.out
+partitions:
+- 10
+- 8
+response_descriptors:
+- y1
+response_files: []
+response_statistics:
+- mean
+responses: response_functions
+run_directory: /Users/mpiper/tmp
+template_file: null
+upper_bounds:
+- 2.0
+- 2.0
+variables: continuous_design

--- a/csdms/dakota/tests/test_experiment.py
+++ b/csdms/dakota/tests/test_experiment.py
@@ -2,7 +2,8 @@
 
 import os
 from nose.tools import (raises, assert_true, assert_equal,
-                        assert_is_instance, assert_is_none)
+                        assert_is_instance, assert_is_none,
+                        assert_is_not_none)
 from csdms.dakota.experiment import Experiment
 
 
@@ -42,6 +43,13 @@ def test_component_sets_interface_type():
     component = 'hydrotrend'
     e = Experiment(component=component)
     assert_is_instance(e.interface, Fork)
+
+
+def test_multidim_parameter_study_uses_bounds():
+    """Test that the multidim parameter study uses bounds."""
+    e = Experiment(method='multidim_parameter_study')
+    assert_is_not_none(e.variables.lower_bounds)
+    assert_is_not_none(e.variables.upper_bounds)
 
 
 def test_get_environment():


### PR DESCRIPTION
The default multidim parameter study created with

```
d = Dakota(method='multidim_parameter_study')
```

was failing because it needs `lower_bounds` and `upper_bounds` defined for its variables. This is slightly awkward, since information has to be passed across Dakota control blocks (from _methods_ to _variables_). I resolved this by applying bounds, but only in the case given above.
