### PR TITLE
Fix default UQ experiments

### DIFF
--- a/dakotathon/method/base.py
+++ b/dakotathon/method/base.py
@@ -139,7 +139,7 @@ class UncertaintyQuantificationBase(MethodBase):
     @abstractmethod
     def __init__(self,
                  basis_polynomial_family='extended',
-                 probability_levels=(),
+                 probability_levels=(0.1, 0.5, 0.9),
                  response_levels=(),
                  samples=10,
                  sample_type='random',
@@ -155,7 +155,7 @@ class UncertaintyQuantificationBase(MethodBase):
           'extended' (the default), 'askey', or 'wiener'.
         probability_levels : list or tuple of float, optional
           Specify probability levels at which to estimate the
-          corresponding response value.
+          corresponding response value. Default is (0.1, 0.5, 0.9).
         response_levels : list or tuple of float, optional
           Values at which to estimate desired statistics for each response
         samples : int

--- a/dakotathon/method/polynomial_chaos.py
+++ b/dakotathon/method/polynomial_chaos.py
@@ -145,6 +145,7 @@ class PolynomialChaos(UncertaintyQuantificationBase):
           polynomial_chaos
             sample_type = random
             samples = 10
+            probability_levels = 0.1 0.5 0.9
             quadrature_order = 2
             non_nested
         <BLANKLINE>

--- a/dakotathon/method/stoch_collocation.py
+++ b/dakotathon/method/stoch_collocation.py
@@ -159,6 +159,7 @@ class StochasticCollocation(UncertaintyQuantificationBase):
           stoch_collocation
             sample_type = random
             samples = 10
+            probability_levels = 0.1 0.5 0.9
             quadrature_order = 2
             non_nested
         <BLANKLINE>

--- a/dakotathon/tests/__init__.py
+++ b/dakotathon/tests/__init__.py
@@ -3,3 +3,10 @@ import os
 
 start_dir = os.path.dirname(__file__)
 data_dir = os.path.join(start_dir, 'data')
+
+dakota_files = {
+    'input': 'dakota.in',
+    'output': 'dakota.out',
+    'data': 'dakota.dat',
+    'restart': 'dakota.rst',
+}

--- a/dakotathon/tests/data/rosenbrock_sampling.in
+++ b/dakotathon/tests/data/rosenbrock_sampling.in
@@ -7,6 +7,7 @@ method
   sampling
     sample_type = random
     samples = 10
+    probability_levels = 0.1 0.5 0.9
 
 variables
   uniform_uncertain = 2

--- a/dakotathon/tests/test_irf.py
+++ b/dakotathon/tests/test_irf.py
@@ -4,13 +4,10 @@ import yaml
 from nose.tools import assert_is, assert_true, assert_equal, with_setup
 from dakotathon.bmi import BmiDakota
 from dakotathon.utils import is_dakota_installed
+from . import dakota_files
 
 
 config_val = {'method': 'vector_parameter_study', 'component': 'hydrotrend'}
-input_file, \
-    output_file, \
-    data_file, \
-    restart_file = ['dakota.' + ext for ext in ('in', 'out', 'dat', 'rst')]
 
 
 def setup():
@@ -20,7 +17,7 @@ def setup():
 
 def teardown():
     """Called at end of any test @with_setup()"""
-    for f in [input_file, output_file, data_file, restart_file]:
+    for f in dakota_files.values():
         if os.path.exists(f):
             os.remove(f)
 
@@ -58,7 +55,7 @@ def test_time_step():
 def test_initialize_defaults():
     model = BmiDakota()
     model.initialize()
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -68,7 +65,7 @@ def test_initialize_from_file_like():
     config = StringIO(yaml.dump(config_val))
     model = BmiDakota()
     model.initialize(config)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -82,7 +79,7 @@ def test_initialize_from_file():
     model = BmiDakota()
     model.initialize(fname)
     os.remove(fname)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 def test_update():
@@ -90,9 +87,9 @@ def test_update():
         model = BmiDakota()
         model.initialize()
         model.update()
-        assert_true(os.path.exists(input_file))
-        assert_true(os.path.exists(output_file))
-        assert_true(os.path.exists(data_file))
+        assert_true(os.path.exists(dakota_files['input']))
+        assert_true(os.path.exists(dakota_files['output']))
+        assert_true(os.path.exists(dakota_files['data']))
 
 
 def test_finalize():

--- a/dakotathon/tests/test_irf_centered_parameter_study.py
+++ b/dakotathon/tests/test_irf_centered_parameter_study.py
@@ -4,13 +4,10 @@ import yaml
 from nose.tools import assert_is, assert_true, assert_equal, with_setup
 from dakotathon.bmi import CenteredParameterStudy
 from dakotathon.utils import is_dakota_installed
+from . import dakota_files
 
 
 config_val = {'method': 'centered_parameter_study'}
-input_file, \
-    output_file, \
-    data_file, \
-    restart_file = ['dakota.' + ext for ext in ('in', 'out', 'dat', 'rst')]
 
 
 def setup():
@@ -20,7 +17,7 @@ def setup():
 
 def teardown():
     """Called at end of any test @with_setup()"""
-    for f in [input_file, output_file, data_file, restart_file]:
+    for f in dakota_files.values():
         if os.path.exists(f):
             os.remove(f)
 
@@ -58,7 +55,7 @@ def test_time_step():
 def test_initialize_defaults():
     model = CenteredParameterStudy()
     model.initialize()
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -68,7 +65,7 @@ def test_initialize_from_file_like():
     config = StringIO(yaml.dump(config_val))
     model = CenteredParameterStudy()
     model.initialize(config)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -82,7 +79,7 @@ def test_initialize_from_file():
     model = CenteredParameterStudy()
     model.initialize(fname)
     os.remove(fname)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 def test_update():
@@ -90,9 +87,9 @@ def test_update():
         model = CenteredParameterStudy()
         model.initialize()
         model.update()
-        assert_true(os.path.exists(input_file))
-        assert_true(os.path.exists(output_file))
-        assert_true(os.path.exists(data_file))
+        assert_true(os.path.exists(dakota_files['input']))
+        assert_true(os.path.exists(dakota_files['output']))
+        assert_true(os.path.exists(dakota_files['data']))
 
 
 def test_finalize():

--- a/dakotathon/tests/test_irf_multidim_parameter_study.py
+++ b/dakotathon/tests/test_irf_multidim_parameter_study.py
@@ -4,14 +4,11 @@ import yaml
 from nose.tools import assert_is, assert_true, assert_equal, with_setup
 from dakotathon.bmi import MultidimParameterStudy
 from dakotathon.utils import is_dakota_installed
+from . import dakota_files
 
 
 config_val = {'method': 'multidim_parameter_study',
               'lower_bounds':[-2,-2], 'upper_bounds':[2,2]}
-input_file, \
-    output_file, \
-    data_file, \
-    restart_file = ['dakota.' + ext for ext in ('in', 'out', 'dat', 'rst')]
 
 
 def setup():
@@ -21,7 +18,7 @@ def setup():
 
 def teardown():
     """Called at end of any test @with_setup()"""
-    for f in [input_file, output_file, data_file, restart_file]:
+    for f in dakota_files.values():
         if os.path.exists(f):
             os.remove(f)
 
@@ -59,7 +56,7 @@ def test_time_step():
 def test_initialize_defaults():
     model = MultidimParameterStudy()
     model.initialize()
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -69,7 +66,7 @@ def test_initialize_from_file_like():
     config = StringIO(yaml.dump(config_val))
     model = MultidimParameterStudy()
     model.initialize(config)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -83,7 +80,7 @@ def test_initialize_from_file():
     model = MultidimParameterStudy()
     model.initialize(fname)
     os.remove(fname)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 def test_update():
@@ -91,9 +88,9 @@ def test_update():
         model = MultidimParameterStudy()
         model.initialize()
         model.update()
-        assert_true(os.path.exists(input_file))
-        assert_true(os.path.exists(output_file))
-        assert_true(os.path.exists(data_file))
+        assert_true(os.path.exists(dakota_files['input']))
+        assert_true(os.path.exists(dakota_files['output']))
+        assert_true(os.path.exists(dakota_files['data']))
 
 
 def test_finalize():

--- a/dakotathon/tests/test_irf_polynomial_chaos.py
+++ b/dakotathon/tests/test_irf_polynomial_chaos.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import yaml
+import glob
 from nose.tools import assert_is, assert_true, assert_equal, with_setup
 from dakotathon.bmi import PolynomialChaos
 from dakotathon.utils import is_dakota_installed
@@ -23,6 +24,11 @@ def teardown():
     for f in [input_file, output_file, data_file, restart_file]:
         if os.path.exists(f):
             os.remove(f)
+    for f in glob.glob('LHS_*'):
+        if os.path.exists(f):
+            os.remove(f)
+    if os.path.exists('S4'):
+        os.remove('S4')
 
 
 def test_component_name():

--- a/dakotathon/tests/test_irf_polynomial_chaos.py
+++ b/dakotathon/tests/test_irf_polynomial_chaos.py
@@ -5,13 +5,10 @@ import glob
 from nose.tools import assert_is, assert_true, assert_equal, with_setup
 from dakotathon.bmi import PolynomialChaos
 from dakotathon.utils import is_dakota_installed
+from . import dakota_files
 
 
 config_val = {'method': 'polynomial_chaos', 'variables': 'uniform_uncertain'}
-input_file, \
-    output_file, \
-    data_file, \
-    restart_file = ['dakota.' + ext for ext in ('in', 'out', 'dat', 'rst')]
 
 
 def setup():
@@ -21,7 +18,7 @@ def setup():
 
 def teardown():
     """Called at end of any test @with_setup()"""
-    for f in [input_file, output_file, data_file, restart_file]:
+    for f in dakota_files.values():
         if os.path.exists(f):
             os.remove(f)
     for f in glob.glob('LHS_*'):
@@ -64,7 +61,7 @@ def test_time_step():
 def test_initialize_defaults():
     model = PolynomialChaos()
     model.initialize()
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -74,7 +71,7 @@ def test_initialize_from_file_like():
     config = StringIO(yaml.dump(config_val))
     model = PolynomialChaos()
     model.initialize(config)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -88,7 +85,7 @@ def test_initialize_from_file():
     model = PolynomialChaos()
     model.initialize(fname)
     os.remove(fname)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 def test_update():
@@ -96,9 +93,9 @@ def test_update():
         model = PolynomialChaos()
         model.initialize()
         model.update()
-        assert_true(os.path.exists(input_file))
-        assert_true(os.path.exists(output_file))
-        assert_true(os.path.exists(data_file))
+        assert_true(os.path.exists(dakota_files['input']))
+        assert_true(os.path.exists(dakota_files['output']))
+        assert_true(os.path.exists(dakota_files['data']))
 
 
 def test_finalize():

--- a/dakotathon/tests/test_irf_sampling.py
+++ b/dakotathon/tests/test_irf_sampling.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import yaml
+import glob
 from nose.tools import assert_is, assert_true, assert_equal, with_setup
 from dakotathon.bmi import Sampling
 from dakotathon.utils import is_dakota_installed
@@ -23,6 +24,11 @@ def teardown():
     for f in [input_file, output_file, data_file, restart_file]:
         if os.path.exists(f):
             os.remove(f)
+    for f in glob.glob('LHS_*'):
+        if os.path.exists(f):
+            os.remove(f)
+    if os.path.exists('S4'):
+        os.remove('S4')
 
 
 def test_component_name():

--- a/dakotathon/tests/test_irf_sampling.py
+++ b/dakotathon/tests/test_irf_sampling.py
@@ -5,13 +5,10 @@ import glob
 from nose.tools import assert_is, assert_true, assert_equal, with_setup
 from dakotathon.bmi import Sampling
 from dakotathon.utils import is_dakota_installed
+from . import dakota_files
 
 
 config_val = {'method': 'sampling', 'variables': 'uniform_uncertain'}
-input_file, \
-    output_file, \
-    data_file, \
-    restart_file = ['dakota.' + ext for ext in ('in', 'out', 'dat', 'rst')]
 
 
 def setup():
@@ -21,7 +18,7 @@ def setup():
 
 def teardown():
     """Called at end of any test @with_setup()"""
-    for f in [input_file, output_file, data_file, restart_file]:
+    for f in dakota_files.values():
         if os.path.exists(f):
             os.remove(f)
     for f in glob.glob('LHS_*'):
@@ -64,7 +61,7 @@ def test_time_step():
 def test_initialize_defaults():
     model = Sampling()
     model.initialize()
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -74,7 +71,7 @@ def test_initialize_from_file_like():
     config = StringIO(yaml.dump(config_val))
     model = Sampling()
     model.initialize(config)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -88,7 +85,7 @@ def test_initialize_from_file():
     model = Sampling()
     model.initialize(fname)
     os.remove(fname)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 def test_update():
@@ -96,9 +93,9 @@ def test_update():
         model = Sampling()
         model.initialize()
         model.update()
-        assert_true(os.path.exists(input_file))
-        assert_true(os.path.exists(output_file))
-        assert_true(os.path.exists(data_file))
+        assert_true(os.path.exists(dakota_files['input']))
+        assert_true(os.path.exists(dakota_files['output']))
+        assert_true(os.path.exists(dakota_files['data']))
 
 
 def test_finalize():

--- a/dakotathon/tests/test_irf_stoch_collocation.py
+++ b/dakotathon/tests/test_irf_stoch_collocation.py
@@ -5,13 +5,10 @@ import glob
 from nose.tools import assert_is, assert_true, assert_equal, with_setup
 from dakotathon.bmi import StochasticCollocation
 from dakotathon.utils import is_dakota_installed
+from . import dakota_files
 
 
 config_val = {'method': 'stoch_collocation', 'variables': 'uniform_uncertain'}
-input_file, \
-    output_file, \
-    data_file, \
-    restart_file = ['dakota.' + ext for ext in ('in', 'out', 'dat', 'rst')]
 
 
 def setup():
@@ -21,7 +18,7 @@ def setup():
 
 def teardown():
     """Called at end of any test @with_setup()"""
-    for f in [input_file, output_file, data_file, restart_file]:
+    for f in dakota_files.values():
         if os.path.exists(f):
             os.remove(f)
     for f in glob.glob('LHS_*'):
@@ -64,7 +61,7 @@ def test_time_step():
 def test_initialize_defaults():
     model = StochasticCollocation()
     model.initialize()
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -74,7 +71,7 @@ def test_initialize_from_file_like():
     config = StringIO(yaml.dump(config_val))
     model = StochasticCollocation()
     model.initialize(config)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -88,7 +85,7 @@ def test_initialize_from_file():
     model = StochasticCollocation()
     model.initialize(fname)
     os.remove(fname)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 def test_update():
@@ -96,9 +93,9 @@ def test_update():
         model = StochasticCollocation()
         model.initialize()
         model.update()
-        assert_true(os.path.exists(input_file))
-        assert_true(os.path.exists(output_file))
-        assert_true(os.path.exists(data_file))
+        assert_true(os.path.exists(dakota_files['input']))
+        assert_true(os.path.exists(dakota_files['output']))
+        assert_true(os.path.exists(dakota_files['data']))
 
 
 def test_finalize():

--- a/dakotathon/tests/test_irf_stoch_collocation.py
+++ b/dakotathon/tests/test_irf_stoch_collocation.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import yaml
+import glob
 from nose.tools import assert_is, assert_true, assert_equal, with_setup
 from dakotathon.bmi import StochasticCollocation
 from dakotathon.utils import is_dakota_installed
@@ -23,6 +24,11 @@ def teardown():
     for f in [input_file, output_file, data_file, restart_file]:
         if os.path.exists(f):
             os.remove(f)
+    for f in glob.glob('LHS_*'):
+        if os.path.exists(f):
+            os.remove(f)
+    if os.path.exists('S4'):
+        os.remove('S4')
 
 
 def test_component_name():

--- a/dakotathon/tests/test_irf_vector_parameter_study.py
+++ b/dakotathon/tests/test_irf_vector_parameter_study.py
@@ -4,13 +4,10 @@ import yaml
 from nose.tools import assert_is, assert_true, assert_equal, with_setup
 from dakotathon.bmi import VectorParameterStudy
 from dakotathon.utils import is_dakota_installed
+from . import dakota_files
 
 
 config_val = {'method': 'vector_parameter_study'}
-input_file, \
-    output_file, \
-    data_file, \
-    restart_file = ['dakota.' + ext for ext in ('in', 'out', 'dat', 'rst')]
 
 
 def setup():
@@ -20,7 +17,7 @@ def setup():
 
 def teardown():
     """Called at end of any test @with_setup()"""
-    for f in [input_file, output_file, data_file, restart_file]:
+    for f in dakota_files.values():
         if os.path.exists(f):
             os.remove(f)
 
@@ -58,7 +55,7 @@ def test_time_step():
 def test_initialize_defaults():
     model = VectorParameterStudy()
     model.initialize()
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -68,7 +65,7 @@ def test_initialize_from_file_like():
     config = StringIO(yaml.dump(config_val))
     model = VectorParameterStudy()
     model.initialize(config)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 @with_setup(setup, teardown)
@@ -82,7 +79,7 @@ def test_initialize_from_file():
     model = VectorParameterStudy()
     model.initialize(fname)
     os.remove(fname)
-    assert_true(os.path.exists(input_file))
+    assert_true(os.path.exists(dakota_files['input']))
 
 
 def test_update():
@@ -90,9 +87,9 @@ def test_update():
         model = VectorParameterStudy()
         model.initialize()
         model.update()
-        assert_true(os.path.exists(input_file))
-        assert_true(os.path.exists(output_file))
-        assert_true(os.path.exists(data_file))
+        assert_true(os.path.exists(dakota_files['input']))
+        assert_true(os.path.exists(dakota_files['output']))
+        assert_true(os.path.exists(dakota_files['data']))
 
 
 def test_finalize():

--- a/dakotathon/tests/test_method_base_uq.py
+++ b/dakotathon/tests/test_method_base_uq.py
@@ -192,7 +192,7 @@ def test_default_str_length():
     """Test the default length of __str__."""
     s = str(c)
     n_lines = len(s.splitlines())
-    assert_equal(n_lines, 5)
+    assert_equal(n_lines, 6)
 
 
 def test_str_length_with_zero_seed_value():
@@ -200,7 +200,7 @@ def test_str_length_with_zero_seed_value():
     x = Concrete(seed=0)
     s = str(x)
     n_lines = len(s.splitlines())
-    assert_equal(n_lines, 4)
+    assert_equal(n_lines, 5)
 
 
 def test_str_length_with_nonzero_seed_value():
@@ -208,7 +208,7 @@ def test_str_length_with_nonzero_seed_value():
     x = Concrete(seed=42)
     s = str(x)
     n_lines = len(s.splitlines())
-    assert_equal(n_lines, 5)
+    assert_equal(n_lines, 6)
 
 
 def test_str_length_with_options():

--- a/dakotathon/tests/test_method_polynomial_chaos.py
+++ b/dakotathon/tests/test_method_polynomial_chaos.py
@@ -121,7 +121,7 @@ def test_default_str_length():
     """Test the default length of __str__."""
     s = str(x)
     n_lines = len(s.splitlines())
-    assert_equal(n_lines, 7)
+    assert_equal(n_lines, 8)
 
 
 def test_str_length_with_options():
@@ -129,4 +129,4 @@ def test_str_length_with_options():
     x = PolynomialChaos(dimension_preference=(1, 2), nested=True)
     s = str(x)
     n_lines = len(s.splitlines())
-    assert_equal(n_lines, 8)
+    assert_equal(n_lines, 9)

--- a/dakotathon/tests/test_method_sampling.py
+++ b/dakotathon/tests/test_method_sampling.py
@@ -49,4 +49,4 @@ def test_str_length():
     """Test the default length of __str__."""
     s = str(x)
     n_lines = len(s.splitlines())
-    assert_equal(n_lines, 5)
+    assert_equal(n_lines, 6)

--- a/dakotathon/tests/test_method_stoch_collocation.py
+++ b/dakotathon/tests/test_method_stoch_collocation.py
@@ -141,7 +141,7 @@ def test_default_str_length():
     """Test the default length of __str__."""
     s = str(x)
     n_lines = len(s.splitlines())
-    assert_equal(n_lines, 7)
+    assert_equal(n_lines, 8)
 
 
 def test_str_length_with_options():
@@ -149,4 +149,4 @@ def test_str_length_with_options():
     m = StochasticCollocation(dimension_preference=(1, 2), nested=True)
     s = str(m)
     n_lines = len(s.splitlines())
-    assert_equal(n_lines, 8)
+    assert_equal(n_lines, 9)


### PR DESCRIPTION
The Dakota experiments created from the default parameters for the PolynomialChaos and StochasticCollocation BMI classes were failing, as shown in #43. I fixed this issue by setting a default value for the `probability_levels` keyword for all Dakota UQ methods.

I also cleaned up
1. the code in several unit tests, and
2. the support files generated by the Dakota RNG. 
