### PR TITLE
Integrate with PyMT

### DIFF
--- a/.bmi/centered_parameter_study/api.yaml
+++ b/.bmi/centered_parameter_study/api.yaml
@@ -2,3 +2,4 @@ name: CenteredParameterStudy
 language: python
 package: dakotathon.bmi
 class: CenteredParameterStudy
+initialize_args: "config.yaml"

--- a/.bmi/centered_parameter_study/api.yaml
+++ b/.bmi/centered_parameter_study/api.yaml
@@ -2,4 +2,4 @@ name: CenteredParameterStudy
 language: python
 package: dakotathon.bmi
 class: CenteredParameterStudy
-initialize_args: "config.yaml"
+initialize_args: "dakota.yaml"

--- a/.bmi/centered_parameter_study/config.yaml.tmpl
+++ b/.bmi/centered_parameter_study/config.yaml.tmpl
@@ -1,35 +1,38 @@
 method: centered_parameter_study
 
-analysis_driver: dakota_run_plugin
+analysis_driver: {analysis_driver}
 asynchronous: false
 auxiliary_files:
-component: {component}          # set by hook
+component: {component}
 configuration_file: config.yaml
 convergence_tolerance:
 data_file: dakota.dat
-descriptors: ["{descriptor1}", "{descriptor2}", "{descriptor3}",]
+descriptors: {descriptors}
 evaluation_concurrency: 2
 gradients: no_gradients
 hessians: no_hessians
-id_interface: CSDMS
-initial_point: [{initial_point1}, {initial_point2}, {initial_point3},]
+id_interface: {id_interface} 
+initial_point: {initial_point}
 input_file: dakota.in
 interface: fork
 lower_bounds:
 max_iterations:
 means:
 output_file: dakota.out
-response_descriptors: ["{response_descriptor1}", "{response_descriptor2}", "{response_descriptor3}",]
-response_files:
-response_statistics: ["{response_statistic1}", "{response_statistic2}", "{response_statistic3}",]
+plugin: {plugin}
+response_descriptors: {response_descriptors}
+response_files: {response_files}
+response_statistics: {response_statistics}
 responses: response_functions
 run_directory: .
 std_deviations:
-steps_per_variable: [{steps_per_variable1}, {steps_per_variable2}, {steps_per_variable3},]
-step_vector: [{step_vector1}, {step_vector2}, {step_vector3},]
-template_file: {template_file}  # set by hook
+steps_per_variable: {steps_per_variable}
+step_vector: {step_vector}
+template_file: "{template_file}"
 upper_bounds:
 variables: continuous_design
 
 # Notes:
-# * BMI handles auxiliary_files and response_files.
+# * The descriptors, initial_point, response_descriptors,
+#   response_statistics, step_per_variable, and step_vector parameters
+#   should be scalars or lists.

--- a/.bmi/centered_parameter_study/dakota.yaml.tmpl
+++ b/.bmi/centered_parameter_study/dakota.yaml.tmpl
@@ -13,6 +13,7 @@ gradients: no_gradients
 hessians: no_hessians
 id_interface: {id_interface} 
 initial_point: {initial_point}
+initialize_args: {initialize_args}
 input_file: dakota.in
 interface: fork
 lower_bounds:

--- a/.bmi/centered_parameter_study/dakota.yaml.tmpl
+++ b/.bmi/centered_parameter_study/dakota.yaml.tmpl
@@ -24,7 +24,7 @@ response_descriptors: {response_descriptors}
 response_files: {response_files}
 response_statistics: {response_statistics}
 responses: response_functions
-run_directory: .
+run_directory: {run_directory}
 std_deviations:
 steps_per_variable: {steps_per_variable}
 step_vector: {step_vector}

--- a/.bmi/centered_parameter_study/dakota.yaml.tmpl
+++ b/.bmi/centered_parameter_study/dakota.yaml.tmpl
@@ -1,25 +1,23 @@
-method: vector_parameter_study
+method: centered_parameter_study
 
 analysis_driver: {analysis_driver}
 asynchronous: false
-auxiliary_files: {auxiliary_files}
+auxiliary_files:
 component: {component}
-configuration_file: config.yaml
+configuration_file: dakota.yaml
 convergence_tolerance:
 data_file: dakota.dat
 descriptors: {descriptors}
 evaluation_concurrency: 2
-final_point: {final_point}
 gradients: no_gradients
 hessians: no_hessians
-id_interface: {id_interface}
+id_interface: {id_interface} 
 initial_point: {initial_point}
 input_file: dakota.in
 interface: fork
 lower_bounds:
 max_iterations:
 means:
-n_steps: {n_steps}
 output_file: dakota.out
 plugin: {plugin}
 response_descriptors: {response_descriptors}
@@ -28,10 +26,13 @@ response_statistics: {response_statistics}
 responses: response_functions
 run_directory: .
 std_deviations:
+steps_per_variable: {steps_per_variable}
+step_vector: {step_vector}
 template_file: "{template_file}"
 upper_bounds:
 variables: continuous_design
 
 # Notes:
-# * The descriptors, final_point, initial_point, response_descriptors,
-#   and response_statistics parameters should be scalars or lists.
+# * The descriptors, initial_point, response_descriptors,
+#   response_statistics, step_per_variable, and step_vector parameters
+#   should be scalars or lists.

--- a/.bmi/centered_parameter_study/dakota.yaml.tmpl
+++ b/.bmi/centered_parameter_study/dakota.yaml.tmpl
@@ -2,7 +2,7 @@ method: centered_parameter_study
 
 analysis_driver: {analysis_driver}
 asynchronous: false
-auxiliary_files:
+auxiliary_files: {auxiliary_files}
 component: {component}
 configuration_file: dakota.yaml
 convergence_tolerance:
@@ -33,6 +33,6 @@ upper_bounds:
 variables: continuous_design
 
 # Notes:
-# * The descriptors, initial_point, response_descriptors,
-#   response_statistics, step_per_variable, and step_vector parameters
-#   should be scalars or lists.
+# * The auxiliary_files, descriptors, initial_point,
+#   response_descriptors, response_statistics, step_per_variable, and
+#   step_vector parameters should be scalars or lists.

--- a/.bmi/centered_parameter_study/parameters.yaml
+++ b/.bmi/centered_parameter_study/parameters.yaml
@@ -1,147 +1,69 @@
-descriptor1:
-  description: Input variable name
+component:
+  description: Name of CSDMS component
   value:
-    type: dynamic_choice
+    type: string
     default:
-    units: '-'
-initial_point1:
-  description: Start point (center value) for study variable
+plugin:
+  description: Name of model plugin
   value:
-    type: float
-    default: 0.0
-    units: '-'
-steps_per_variable1:
-  description: Number of steps to take in each direction
-  value:
-    type: int
-    default: 1
-    range:
-      min: 1
-      max: 100
-    units: '-'
-step_vector1:
-  description: Step size in each direction
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: 1e-6
-      max: 1e+6
-    units: '-'
-descriptor2:
-  description: Input variable name
-  value:
-    type: dynamic_choice
+    type: string
     default:
-    units: '-'
-initial_point2:
-  description: Start point (center value) for study variable
+template_file:
+  description: Dakota template of model configuration file
   value:
-    type: float
-    default: 0.0
-    units: '-'
-steps_per_variable2:
-  description: Number of steps to take in each direction
+    type: string
+    default: 'config.yaml.dtmpl'
+auxiliary_files:
+  description: Additional model input files
   value:
-    type: int
-    default: 1
-    range:
-      min: 1
-      max: 100
-    units: '-'
-step_vector2:
-  description: Step size in each direction
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: 1e-6
-      max: 1e+6
-    units: '-'
-descriptor3:
-  description: Input variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-initial_point3:
-  description: Start point (center value) for study variable
-  value:
-    type: float
-    default: 0.0
-    units: '-'
-steps_per_variable3:
-  description: Number of steps to take in each direction
-  value:
-    type: int
-    default: 1
-    range:
-      min: 1
-      max: 100
-    units: '-'
-step_vector3:
-  description: Step size in each direction
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: 1e-6
-      max: 1e+6
-    units: '-'
-response_descriptor1:
-  description: Response variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic1:
-  description: Statistic computed on response
+    type: list
+    default: []
+analysis_driver:
+  description: Dakota analysis driver program
   value:
     type: choice
-    default: Mean
+    default: dakota_run_plugin
     choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-response_descriptor2:
+      - dakota_run_plugin
+      - dakota_run_component
+id_interface:
+  description: Name of the interface block
+  value:
+    type: string
+    default: CSDMS
+
+descriptors:
+  description: Input variable name
+  value:
+    type: list
+    default: []
+initial_point:
+  description: Start point (center value) for study variable
+  value:
+    type: list
+    default: [0.0]
+steps_per_variable:
+  description: Number of steps to take in each direction
+  value:
+    type: list
+    default: [1]
+step_vector:
+  description: Step size in each direction
+  value:
+    type: list
+    default: [1.0]
+response_descriptors:
   description: Response variable name
   value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic2:
+    type: list
+    default: []
+response_files:
+  description: Model output files used for calculating response
+  value:
+    type: list
+    default: []
+response_statistics:
   description: Statistic computed on response
   value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-response_descriptor3:
-  description: Response variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic3:
-  description: Statistic computed on response
-  value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
+    type: list
+    default: ['mean']

--- a/.bmi/centered_parameter_study/parameters.yaml
+++ b/.bmi/centered_parameter_study/parameters.yaml
@@ -12,7 +12,7 @@ template_file:
   description: Dakota template of model configuration file
   value:
     type: string
-    default: 'config.yaml.dtmpl'
+    default: 'dakota.yaml.dtmpl'
 auxiliary_files:
   description: Additional model input files
   value:

--- a/.bmi/centered_parameter_study/parameters.yaml
+++ b/.bmi/centered_parameter_study/parameters.yaml
@@ -8,6 +8,11 @@ plugin:
   value:
     type: string
     default:
+run_directory:
+  description: Directory in which Dakota experiment is run
+  value:
+    type: string
+    default: '.'
 template_file:
   description: Dakota template of model configuration file
   value:

--- a/.bmi/centered_parameter_study/parameters.yaml
+++ b/.bmi/centered_parameter_study/parameters.yaml
@@ -36,6 +36,11 @@ id_interface:
   value:
     type: string
     default: CSDMS
+initialize_args:
+  description: Arguments passed to component initialize method
+  value:
+    type: string
+    default: ''
 
 descriptors:
   description: Input variable name

--- a/.bmi/multidim_parameter_study/api.yaml
+++ b/.bmi/multidim_parameter_study/api.yaml
@@ -2,3 +2,4 @@ name: MultidimParameterStudy
 language: python
 package: dakotathon.bmi
 class: MultidimParameterStudy
+initialize_args: "config.yaml"

--- a/.bmi/multidim_parameter_study/api.yaml
+++ b/.bmi/multidim_parameter_study/api.yaml
@@ -2,4 +2,4 @@ name: MultidimParameterStudy
 language: python
 package: dakotathon.bmi
 class: MultidimParameterStudy
-initialize_args: "config.yaml"
+initialize_args: "dakota.yaml"

--- a/.bmi/multidim_parameter_study/config.yaml.tmpl
+++ b/.bmi/multidim_parameter_study/config.yaml.tmpl
@@ -1,34 +1,37 @@
 method: multidim_parameter_study
 
-analysis_driver: dakota_run_plugin
+analysis_driver: {analysis_driver}
 asynchronous: false
 auxiliary_files:
-component: {component}          # set by hook
+component: {component}
 configuration_file: config.yaml
 convergence_tolerance:
 data_file: dakota.dat
-descriptors: ["{descriptor1}", "{descriptor2}", "{descriptor3}",]
+descriptors: {descriptors}
 evaluation_concurrency: 2
 gradients: no_gradients
 hessians: no_hessians
-id_interface: CSDMS
+id_interface: {id_interface} 
 initial_point:
 input_file: dakota.in
 interface: fork
-lower_bounds: [{lower_bound1}, {lower_bound2}, {lower_bound3},]
+lower_bounds: {lower_bounds}
 max_iterations:
 means:
 output_file: dakota.out
-partitions: [{partition1}, {partition2}, {partition3},]
-response_descriptors: ["{response_descriptor1}", "{response_descriptor2}", "{response_descriptor3}",]
-response_files:
-response_statistics: ["{response_statistic1}", "{response_statistic2}", "{response_statistic3}",]
+partitions: {partitions}
+plugin: {plugin}
+response_descriptors: {response_descriptors}
+response_files: {response_files}
+response_statistics: {response_statistics}
 responses: response_functions
 run_directory: .
 std_deviations:
-template_file: {template_file}  # set by hook
-upper_bounds: [{upper_bound1}, {upper_bound2}, {upper_bound3},]
+template_file: "{template_file}"
+upper_bounds: {upper_bound}
 variables: continuous_design
 
 # Notes:
-# * BMI handles auxiliary_files and response_files.
+# * The descriptors, initial_point, lower_bounds, partitions,
+#   response_descriptors, response_statistics, and upper_bounds
+#   parameters should be scalars or lists.

--- a/.bmi/multidim_parameter_study/dakota.yaml.tmpl
+++ b/.bmi/multidim_parameter_study/dakota.yaml.tmpl
@@ -1,10 +1,10 @@
-method: centered_parameter_study
+method: multidim_parameter_study
 
 analysis_driver: {analysis_driver}
 asynchronous: false
 auxiliary_files:
 component: {component}
-configuration_file: config.yaml
+configuration_file: dakota.yaml
 convergence_tolerance:
 data_file: dakota.dat
 descriptors: {descriptors}
@@ -12,13 +12,14 @@ evaluation_concurrency: 2
 gradients: no_gradients
 hessians: no_hessians
 id_interface: {id_interface} 
-initial_point: {initial_point}
+initial_point:
 input_file: dakota.in
 interface: fork
-lower_bounds:
+lower_bounds: {lower_bounds}
 max_iterations:
 means:
 output_file: dakota.out
+partitions: {partitions}
 plugin: {plugin}
 response_descriptors: {response_descriptors}
 response_files: {response_files}
@@ -26,13 +27,11 @@ response_statistics: {response_statistics}
 responses: response_functions
 run_directory: .
 std_deviations:
-steps_per_variable: {steps_per_variable}
-step_vector: {step_vector}
 template_file: "{template_file}"
-upper_bounds:
+upper_bounds: {upper_bound}
 variables: continuous_design
 
 # Notes:
-# * The descriptors, initial_point, response_descriptors,
-#   response_statistics, step_per_variable, and step_vector parameters
-#   should be scalars or lists.
+# * The descriptors, initial_point, lower_bounds, partitions,
+#   response_descriptors, response_statistics, and upper_bounds
+#   parameters should be scalars or lists.

--- a/.bmi/multidim_parameter_study/dakota.yaml.tmpl
+++ b/.bmi/multidim_parameter_study/dakota.yaml.tmpl
@@ -25,7 +25,7 @@ response_descriptors: {response_descriptors}
 response_files: {response_files}
 response_statistics: {response_statistics}
 responses: response_functions
-run_directory: .
+run_directory: {run_directory}
 std_deviations:
 template_file: "{template_file}"
 upper_bounds: {upper_bounds}

--- a/.bmi/multidim_parameter_study/dakota.yaml.tmpl
+++ b/.bmi/multidim_parameter_study/dakota.yaml.tmpl
@@ -2,7 +2,7 @@ method: multidim_parameter_study
 
 analysis_driver: {analysis_driver}
 asynchronous: false
-auxiliary_files:
+auxiliary_files: {auxiliary_files}
 component: {component}
 configuration_file: dakota.yaml
 convergence_tolerance:
@@ -32,6 +32,6 @@ upper_bounds: {upper_bounds}
 variables: continuous_design
 
 # Notes:
-# * The descriptors, initial_point, lower_bounds, partitions,
-#   response_descriptors, response_statistics, and upper_bounds
-#   parameters should be scalars or lists.
+# * The auxiliary_files, descriptors, initial_point, lower_bounds,
+#   partitions, response_descriptors, response_statistics, and
+#   upper_bounds parameters should be scalars or lists.

--- a/.bmi/multidim_parameter_study/dakota.yaml.tmpl
+++ b/.bmi/multidim_parameter_study/dakota.yaml.tmpl
@@ -28,7 +28,7 @@ responses: response_functions
 run_directory: .
 std_deviations:
 template_file: "{template_file}"
-upper_bounds: {upper_bound}
+upper_bounds: {upper_bounds}
 variables: continuous_design
 
 # Notes:

--- a/.bmi/multidim_parameter_study/dakota.yaml.tmpl
+++ b/.bmi/multidim_parameter_study/dakota.yaml.tmpl
@@ -13,6 +13,7 @@ gradients: no_gradients
 hessians: no_hessians
 id_interface: {id_interface} 
 initial_point:
+initialize_args: {initialize_args}
 input_file: dakota.in
 interface: fork
 lower_bounds: {lower_bounds}

--- a/.bmi/multidim_parameter_study/parameters.yaml
+++ b/.bmi/multidim_parameter_study/parameters.yaml
@@ -12,7 +12,7 @@ template_file:
   description: Dakota template of model configuration file
   value:
     type: string
-    default: 'config.yaml.dtmpl'
+    default: 'dakota.yaml.dtmpl'
 auxiliary_files:
   description: Additional model input files
   value:

--- a/.bmi/multidim_parameter_study/parameters.yaml
+++ b/.bmi/multidim_parameter_study/parameters.yaml
@@ -1,156 +1,69 @@
-descriptor1:
+component:
+  description: Name of CSDMS component
+  value:
+    type: string
+    default:
+plugin:
+  description: Name of model plugin
+  value:
+    type: string
+    default:
+template_file:
+  description: Dakota template of model configuration file
+  value:
+    type: string
+    default: 'config.yaml.dtmpl'
+auxiliary_files:
+  description: Additional model input files
+  value:
+    type: list
+    default: []
+analysis_driver:
+  description: Dakota analysis driver program
+  value:
+    type: choice
+    default: dakota_run_plugin
+    choices:
+      - dakota_run_plugin
+      - dakota_run_component
+id_interface:
+  description: Name of the interface block
+  value:
+    type: string
+    default: CSDMS
+
+descriptors:
   description: Input variable name
   value:
-    type: dynamic_choice
-    default:
-    units: '-'
-lower_bound1:
+    type: list
+    default: []
+lower_bounds:
   description: Lower bound on values of study variable
   value:
     type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-upper_bound1:
+    default: [0.0]
+upper_bounds:
   description: Upper bound on values of study variable
   value:
-    type: float
-    default: 1.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-partition1:
+    type: list
+    default: [1.0]
+partitions:
   description: Number of partitions between lower and upper bounds
   value:
-    type: int
-    default: 2
-    range:
-      min: 1
-      max: 1e2
-    units: '-'
-descriptor2:
-  description: Input variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-lower_bound2:
-  description: Lower bound on values of study variable
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-upper_bound2:
-  description: Upper bound on values of study variable
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-partition2:
-  description: Number of partitions between lower and upper bounds
-  value:
-    type: int
-    default: 1
-    range:
-      min: 2
-      max: 1e2
-    units: '-'
-descriptor3:
-  description: Input variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-lower_bound3:
-  description: Lower bound on values of study variable
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-upper_bound3:
-  description: Upper bound on values of study variable
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-partition3:
-  description: Number of partitions between lower and upper bounds
-  value:
-    type: int
-    default: 1
-    range:
-      min: 2
-      max: 1e2
-    units: '-'
-response_descriptor1:
+    type: list
+    default: [2]
+response_descriptors:
   description: Response variable name
   value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic1:
+    type: list
+    default: []
+response_statistics:
   description: Statistic computed on response
   value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-response_descriptor2:
-  description: Response variable name
+    type: list
+    default: ['mean']
+response_files:
+  description: Model output files used for calculating response
   value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic2:
-  description: Statistic computed on response
-  value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-response_descriptor3:
-  description: Response variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic3:
-  description: Statistic computed on response
-  value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
+    type: list
+    default: []

--- a/.bmi/multidim_parameter_study/parameters.yaml
+++ b/.bmi/multidim_parameter_study/parameters.yaml
@@ -8,6 +8,11 @@ plugin:
   value:
     type: string
     default:
+run_directory:
+  description: Directory in which Dakota experiment is run
+  value:
+    type: string
+    default: '.'
 template_file:
   description: Dakota template of model configuration file
   value:

--- a/.bmi/multidim_parameter_study/parameters.yaml
+++ b/.bmi/multidim_parameter_study/parameters.yaml
@@ -36,6 +36,11 @@ id_interface:
   value:
     type: string
     default: CSDMS
+initialize_args:
+  description: Arguments passed to component initialize method
+  value:
+    type: string
+    default: ''
 
 descriptors:
   description: Input variable name

--- a/.bmi/polynomial_chaos/api.yaml
+++ b/.bmi/polynomial_chaos/api.yaml
@@ -2,3 +2,4 @@ name: PolynomialChaos
 language: python
 package: dakotathon.bmi
 class: PolynomialChaos
+initialize_args: "config.yaml"

--- a/.bmi/polynomial_chaos/api.yaml
+++ b/.bmi/polynomial_chaos/api.yaml
@@ -2,4 +2,4 @@ name: PolynomialChaos
 language: python
 package: dakotathon.bmi
 class: PolynomialChaos
-initialize_args: "config.yaml"
+initialize_args: "dakota.yaml"

--- a/.bmi/polynomial_chaos/config.yaml.tmpl
+++ b/.bmi/polynomial_chaos/config.yaml.tmpl
@@ -1,77 +1,51 @@
 method: polynomial_chaos
 
-analysis_driver: dakota_run_plugin
+analysis_driver: {analysis_driver}
 asynchronous: false
-auxiliary_files:
+auxiliary_files: {auxiliary_files}
 basis_polynomial_family: extended
 coefficient_estimation_approach: quadrature_order_sequence
-component: {component}          # set by hook
+component: {component}
 configuration_file: config.yaml
 convergence_tolerance:
 data_file: dakota.dat
-descriptors:
-- "{descriptor1}"
-- "{descriptor2}"
-- "{descriptor3}"
+descriptors: {descriptors}
 dimension_preference:
 evaluation_concurrency: 2
 gradients: no_gradients
 hessians: no_hessians
-id_interface: CSDMS
+id_interface: {id_interface} 
 initial_point:
 input_file: dakota.in
 interface: fork
-lower_bounds:
-- {lower_bound1}
-- {lower_bound2}
-- {lower_bound3}
+lower_bounds: {lower_bounds}
 max_iterations:
-means:
-- {mean1}
-- {mean2}
-- {mean3}
+means: {means}
 nested: false
 output_file: dakota.out
-probability_levels:
-- {probability_levels1}
-- {probability_levels2}
-- {probability_levels3}
+plugin: {plugin}
+probability_levels: {probability_levels}
 quadrature_order: {quadrature_order} 
-response_descriptors:
-- "{response_descriptor1}"
-- "{response_descriptor2}"
-- "{response_descriptor3}"
-response_files:
-response_levels:
-- {response_levels1}
-- {response_levels2}
-- {response_levels3}
-response_statistics:
-- "{response_statistic1}"
-- "{response_statistic2}"
-- "{response_statistic3}"
+response_descriptors: {response_descriptors}
+response_files: {response_files}
+response_levels: {response_levels}
+response_statistics: {response_statistics}
 responses: response_functions
 run_directory: .
 sample_type: "{sample_type}"
 samples: {samples}
 seed: {seed}
-std_deviations:
-- {std_deviation1}
-- {std_deviation2}
-- {std_deviation3}
-template_file: {template_file}  # set by hook
-upper_bounds:
-- {upper_bound1}
-- {upper_bound2}
-- {upper_bound3}
+std_deviations: {std_deviations}
+template_file: "{template_file}"
+upper_bounds: {upper_bounds}
 variables: "{variable_type}"
 variance_based_decomp: {variance_based_decomp}
 
 # Notes:
 # * For uniform_uncertain variables, ignore means and std_deviations.
-# * The values of response_levels and probability_levels need to be
-#   converted to lists.
-# * BMI handles auxiliary_files and response_files.
+# * The descriptors, lower_bounds, upper_bounds, means, std_deviations,
+#   probability_levels, response_levels, response_descriptors,
+#   and response_statistics parameters should be scalars or lists.
 # * coefficient_estimation_approach must be set, but the only option
 #   currently is quadrature_order_sequence.
 # * dimension_preference isn't implemented.

--- a/.bmi/polynomial_chaos/dakota.yaml.tmpl
+++ b/.bmi/polynomial_chaos/dakota.yaml.tmpl
@@ -16,6 +16,7 @@ gradients: no_gradients
 hessians: no_hessians
 id_interface: {id_interface} 
 initial_point:
+initialize_args: {initialize_args}
 input_file: dakota.in
 interface: fork
 lower_bounds: {lower_bounds}

--- a/.bmi/polynomial_chaos/dakota.yaml.tmpl
+++ b/.bmi/polynomial_chaos/dakota.yaml.tmpl
@@ -31,7 +31,7 @@ response_files: {response_files}
 response_levels: {response_levels}
 response_statistics: {response_statistics}
 responses: response_functions
-run_directory: .
+run_directory: {run_directory}
 sample_type: "{sample_type}"
 samples: {samples}
 seed: {seed}

--- a/.bmi/polynomial_chaos/dakota.yaml.tmpl
+++ b/.bmi/polynomial_chaos/dakota.yaml.tmpl
@@ -1,14 +1,16 @@
-method: sampling
+method: polynomial_chaos
 
 analysis_driver: {analysis_driver}
 asynchronous: false
 auxiliary_files: {auxiliary_files}
 basis_polynomial_family: extended
+coefficient_estimation_approach: quadrature_order_sequence
 component: {component}
-configuration_file: config.yaml
+configuration_file: dakota.yaml
 convergence_tolerance:
 data_file: dakota.dat
 descriptors: {descriptors}
+dimension_preference:
 evaluation_concurrency: 2
 gradients: no_gradients
 hessians: no_hessians
@@ -19,9 +21,11 @@ interface: fork
 lower_bounds: {lower_bounds}
 max_iterations:
 means: {means}
+nested: false
 output_file: dakota.out
 plugin: {plugin}
 probability_levels: {probability_levels}
+quadrature_order: {quadrature_order} 
 response_descriptors: {response_descriptors}
 response_files: {response_files}
 response_levels: {response_levels}
@@ -42,3 +46,6 @@ variance_based_decomp: {variance_based_decomp}
 # * The descriptors, lower_bounds, upper_bounds, means, std_deviations,
 #   probability_levels, response_levels, response_descriptors,
 #   and response_statistics parameters should be scalars or lists.
+# * coefficient_estimation_approach must be set, but the only option
+#   currently is quadrature_order_sequence.
+# * dimension_preference isn't implemented.

--- a/.bmi/polynomial_chaos/parameters.yaml
+++ b/.bmi/polynomial_chaos/parameters.yaml
@@ -1,233 +1,97 @@
-descriptor1:
-  description: Input variable name
+component:
+  description: Name of CSDMS component
   value:
-    type: dynamic_choice
+    type: string
     default:
-    units: '-'
-lower_bound1:
-  description: Lower bound on values of study variable
+plugin:
+  description: Name of model plugin
   value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-upper_bound1:
-  description: Upper bound on values of study variable
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-mean1:
-  description: Mean of the distribution
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-std_deviation1:
-  description: Standard deviation of the distribution
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: 1e-6
-      max: 1e6
-    units: '-'
-
-descriptor2:
-  description: Input variable name
-  value:
-    type: dynamic_choice
+    type: string
     default:
-    units: '-'
-lower_bound2:
-  description: Lower bound on values of study variable
+template_file:
+  description: Dakota template of model configuration file
   value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-upper_bound2:
-  description: Upper bound on values of study variable
+    type: string
+    default: 'config.yaml.dtmpl'
+auxiliary_files:
+  description: Additional model input files
   value:
-    type: float
-    default: 1.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-mean2:
-  description: Mean of the distribution
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-std_deviation2:
-  description: Standard deviation of the distribution
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: 1e-6
-      max: 1e6
-    units: '-'
-
-descriptor3:
-  description: Input variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-lower_bound3:
-  description: Lower bound on values of study variable
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-upper_bound3:
-  description: Upper bound on values of study variable
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-mean3:
-  description: Mean of the distribution
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-std_deviation3:
-  description: Standard deviation of the distribution
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: 1e-6
-      max: 1e6
-    units: '-'
-
-response_descriptor1:
-  description: Response variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic1:
-  description: Statistic computed on response
+    type: list
+    default: []
+analysis_driver:
+  description: Dakota analysis driver program
   value:
     type: choice
-    default: Mean
+    default: dakota_run_plugin
     choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-probability_levels1:
-  description:
-    Probabilities at which to estimate response values (a comma-delimited list)
+      - dakota_run_plugin
+      - dakota_run_component
+id_interface:
+  description: Name of the interface block
   value:
     type: string
-    default: ''
-    units: '-'
-response_levels1:
-  description:
-    Levels at which to estimate response PDF and CDF (a comma-delimited list)
-  value:
-    type: string
-    default: ''
-    units: '-'
+    default: CSDMS
 
-response_descriptor2:
-  description: Response variable name
+descriptors:
+  description:
+    Input variable name
   value:
-    type: dynamic_choice
+    type: list
     default:
-    units: '-'
-response_statistic2:
-  description: Statistic computed on response
-  value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-probability_levels2:
+lower_bounds:
   description:
-    Probabilities at which to estimate response values (a comma-delimited list)
+    Lower bound on values of study variable
   value:
-    type: string
-    default: ''
-    units: '-'
-response_levels2:
+    type: list
+    default: [0.0]
+upper_bounds:
   description:
-    Levels at which to estimate response PDF and CDF (a comma-delimited list)
+    Upper bound on values of study variable
   value:
-    type: string
-    default: ''
-    units: '-'
+    type: list
+    default: [1.0]
+means:
+  description:
+    Mean of the study variable distribution
+  value:
+    type: list
+    default: [0.0]
+std_deviations:
+  description:
+    Standard deviation of the study variable distribution
+  value:
+    type: list
+    default: [1.0]
 
-response_descriptor3:
-  description: Response variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic3:
-  description: Statistic computed on response
-  value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-probability_levels3:
+response_descriptors:
   description:
-    Probabilities at which to estimate response values (a comma-delimited list)
+    Response variable name
   value:
-    type: string
-    default: ''
-    units: '-'
-response_levels3:
+    type: list
+    default: []
+response_statistics:
   description:
-    Levels at which to estimate response PDF and CDF (a comma-delimited list)
+    Statistic computed on response
   value:
-    type: string
-    default: ''
-    units: '-'
+    type: list
+    default: ['mean']
+probability_levels:
+  description:
+    Probabilities at which to estimate response values
+  value:
+    type: list
+    default: [0.1, 0.5, 0.9]
+response_levels:
+  description:
+    Levels at which to estimate response PDF and CDF
+  value:
+    type: list
+    default: []
+response_files:
+  description: Model output files used for calculating response
+  value:
+    type: list
+    default: []
 
 quadrature_order:
   description:
@@ -244,7 +108,6 @@ quadrature_order:
       - 6
       - 7
       - 8
-    units: '-'
 sample_type:
   description:
     Technique for choosing samples
@@ -254,7 +117,6 @@ sample_type:
     choices:
       - Random sampling
       - Latin hypercube sampling
-    units: '-'
 samples:
   description:
     Number of samples in experiment
@@ -264,7 +126,6 @@ samples:
     range:
       min: 1
       max: 1e6
-    units: '-'
 seed:
   description:
     Seed for random number generator (0 = randomly selected)
@@ -274,7 +135,6 @@ seed:
     range:
       min: 0
       max: 1e6
-    units: '-'
 variance_based_decomp:
   description:
     Activate global sensitivity analysis based on decomposition of response variance
@@ -284,7 +144,6 @@ variance_based_decomp:
     choices:
       - False
       - True
-    units: '-'
 variable_type:
   description:
     Variable type used in the experiment
@@ -294,4 +153,3 @@ variable_type:
     choices:
       - Uniform uncertain
       - Normal uncertain
-    units: '-'

--- a/.bmi/polynomial_chaos/parameters.yaml
+++ b/.bmi/polynomial_chaos/parameters.yaml
@@ -12,7 +12,7 @@ template_file:
   description: Dakota template of model configuration file
   value:
     type: string
-    default: 'config.yaml.dtmpl'
+    default: 'dakota.yaml.dtmpl'
 auxiliary_files:
   description: Additional model input files
   value:

--- a/.bmi/polynomial_chaos/parameters.yaml
+++ b/.bmi/polynomial_chaos/parameters.yaml
@@ -8,6 +8,11 @@ plugin:
   value:
     type: string
     default:
+run_directory:
+  description: Directory in which Dakota experiment is run
+  value:
+    type: string
+    default: '.'
 template_file:
   description: Dakota template of model configuration file
   value:

--- a/.bmi/polynomial_chaos/parameters.yaml
+++ b/.bmi/polynomial_chaos/parameters.yaml
@@ -36,6 +36,11 @@ id_interface:
   value:
     type: string
     default: CSDMS
+initialize_args:
+  description: Arguments passed to component initialize method
+  value:
+    type: string
+    default: ''
 
 descriptors:
   description:

--- a/.bmi/sampling/api.yaml
+++ b/.bmi/sampling/api.yaml
@@ -2,3 +2,4 @@ name: Sampling
 language: python
 package: dakotathon.bmi
 class: Sampling
+initialize_args: "config.yaml"

--- a/.bmi/sampling/api.yaml
+++ b/.bmi/sampling/api.yaml
@@ -2,4 +2,4 @@ name: Sampling
 language: python
 package: dakotathon.bmi
 class: Sampling
-initialize_args: "config.yaml"
+initialize_args: "dakota.yaml"

--- a/.bmi/sampling/config.yaml.tmpl
+++ b/.bmi/sampling/config.yaml.tmpl
@@ -1,43 +1,44 @@
 method: sampling
 
-analysis_driver: dakota_run_plugin
+analysis_driver: {analysis_driver}
 asynchronous: false
-auxiliary_files:
+auxiliary_files: {auxiliary_files}
 basis_polynomial_family: extended
-component: {component}          # set by hook
+component: {component}
 configuration_file: config.yaml
 convergence_tolerance:
 data_file: dakota.dat
-descriptors: ["{descriptor1}", "{descriptor2}", "{descriptor3}",]
+descriptors: {descriptors}
 evaluation_concurrency: 2
 gradients: no_gradients
 hessians: no_hessians
-id_interface: CSDMS
+id_interface: {id_interface} 
 initial_point:
 input_file: dakota.in
 interface: fork
-lower_bounds: [{lower_bound1}, {lower_bound2}, {lower_bound3},]
+lower_bounds: {lower_bounds}
 max_iterations:
-means: [{mean1}, {mean2}, {mean3},]
+means: {means}
 output_file: dakota.out
-probability_levels: [{probability_levels1}, {probability_levels2}, {probability_levels3},]
-response_descriptors: ["{response_descriptor1}", "{response_descriptor2}", "{response_descriptor3}",]
-response_files:
-response_levels: [{response_levels1}, {response_levels2}, {response_levels3},]
-response_statistics: ["{response_statistic1}", "{response_statistic2}", "{response_statistic3}",]
+plugin: {plugin}
+probability_levels: {probability_levels}
+response_descriptors: {response_descriptors}
+response_files: {response_files}
+response_levels: {response_levels}
+response_statistics: {response_statistics}
 responses: response_functions
 run_directory: .
 sample_type: "{sample_type}"
 samples: {samples}
 seed: {seed}
-std_deviations: [{std_deviation1}, {std_deviation2}, {std_deviation3},]
-template_file: {template_file}  # set by hook
-upper_bounds: [{upper_bound1}, {upper_bound2}, {upper_bound3},]
+std_deviations: {std_deviations}
+template_file: "{template_file}"
+upper_bounds: {upper_bounds}
 variables: "{variable_type}"
 variance_based_decomp: {variance_based_decomp}
 
 # Notes:
 # * For uniform_uncertain variables, ignore means and std_deviations.
-# * The values of response_levels and probability_levels need to be
-#   converted to lists.
-# * BMI handles auxiliary_files and response_files.
+# * The descriptors, lower_bounds, upper_bounds, means, std_deviations,
+#   probability_levels, response_levels, response_descriptors,
+#   and response_statistics parameters should be scalars or lists.

--- a/.bmi/sampling/dakota.yaml.tmpl
+++ b/.bmi/sampling/dakota.yaml.tmpl
@@ -14,6 +14,7 @@ gradients: no_gradients
 hessians: no_hessians
 id_interface: {id_interface} 
 initial_point:
+initialize_args: {initialize_args}
 input_file: dakota.in
 interface: fork
 lower_bounds: {lower_bounds}

--- a/.bmi/sampling/dakota.yaml.tmpl
+++ b/.bmi/sampling/dakota.yaml.tmpl
@@ -1,16 +1,14 @@
-method: stoch_collocation
+method: sampling
 
 analysis_driver: {analysis_driver}
 asynchronous: false
 auxiliary_files: {auxiliary_files}
 basis_polynomial_family: extended
-coefficient_estimation_approach: quadrature_order_sequence
 component: {component}
-configuration_file: config.yaml
+configuration_file: dakota.yaml
 convergence_tolerance:
 data_file: dakota.dat
 descriptors: {descriptors}
-dimension_preference:
 evaluation_concurrency: 2
 gradients: no_gradients
 hessians: no_hessians
@@ -21,11 +19,9 @@ interface: fork
 lower_bounds: {lower_bounds}
 max_iterations:
 means: {means}
-nested: false
 output_file: dakota.out
 plugin: {plugin}
 probability_levels: {probability_levels}
-quadrature_order: {quadrature_order} 
 response_descriptors: {response_descriptors}
 response_files: {response_files}
 response_levels: {response_levels}
@@ -46,6 +42,3 @@ variance_based_decomp: {variance_based_decomp}
 # * The descriptors, lower_bounds, upper_bounds, means, std_deviations,
 #   probability_levels, response_levels, response_descriptors,
 #   and response_statistics parameters should be scalars or lists.
-# * coefficient_estimation_approach must be set, but the only option
-#   currently is quadrature_order_sequence.
-# * dimension_preference isn't implemented.

--- a/.bmi/sampling/dakota.yaml.tmpl
+++ b/.bmi/sampling/dakota.yaml.tmpl
@@ -27,7 +27,7 @@ response_files: {response_files}
 response_levels: {response_levels}
 response_statistics: {response_statistics}
 responses: response_functions
-run_directory: .
+run_directory: {run_directory}
 sample_type: "{sample_type}"
 samples: {samples}
 seed: {seed}

--- a/.bmi/sampling/parameters.yaml
+++ b/.bmi/sampling/parameters.yaml
@@ -12,7 +12,7 @@ template_file:
   description: Dakota template of model configuration file
   value:
     type: string
-    default: 'config.yaml.dtmpl'
+    default: 'dakota.yaml.dtmpl'
 auxiliary_files:
   description: Additional model input files
   value:

--- a/.bmi/sampling/parameters.yaml
+++ b/.bmi/sampling/parameters.yaml
@@ -8,6 +8,11 @@ plugin:
   value:
     type: string
     default:
+run_directory:
+  description: Directory in which Dakota experiment is run
+  value:
+    type: string
+    default: '.'
 template_file:
   description: Dakota template of model configuration file
   value:

--- a/.bmi/sampling/parameters.yaml
+++ b/.bmi/sampling/parameters.yaml
@@ -36,6 +36,11 @@ id_interface:
   value:
     type: string
     default: CSDMS
+initialize_args:
+  description: Arguments passed to component initialize method
+  value:
+    type: string
+    default: ''
 
 descriptors:
   description:

--- a/.bmi/sampling/parameters.yaml
+++ b/.bmi/sampling/parameters.yaml
@@ -1,233 +1,97 @@
-descriptor1:
-  description: Input variable name
+component:
+  description: Name of CSDMS component
   value:
-    type: dynamic_choice
+    type: string
     default:
-    units: '-'
-lower_bound1:
-  description: Lower bound on values of study variable
+plugin:
+  description: Name of model plugin
   value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-upper_bound1:
-  description: Upper bound on values of study variable
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-mean1:
-  description: Mean of the distribution
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-std_deviation1:
-  description: Standard deviation of the distribution
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: 1e-6
-      max: 1e6
-    units: '-'
-
-descriptor2:
-  description: Input variable name
-  value:
-    type: dynamic_choice
+    type: string
     default:
-    units: '-'
-lower_bound2:
-  description: Lower bound on values of study variable
+template_file:
+  description: Dakota template of model configuration file
   value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-upper_bound2:
-  description: Upper bound on values of study variable
+    type: string
+    default: 'config.yaml.dtmpl'
+auxiliary_files:
+  description: Additional model input files
   value:
-    type: float
-    default: 1.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-mean2:
-  description: Mean of the distribution
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-std_deviation2:
-  description: Standard deviation of the distribution
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: 1e-6
-      max: 1e6
-    units: '-'
-
-descriptor3:
-  description: Input variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-lower_bound3:
-  description: Lower bound on values of study variable
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-upper_bound3:
-  description: Upper bound on values of study variable
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-mean3:
-  description: Mean of the distribution
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-std_deviation3:
-  description: Standard deviation of the distribution
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: 1e-6
-      max: 1e6
-    units: '-'
-
-response_descriptor1:
-  description: Response variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic1:
-  description: Statistic computed on response
+    type: list
+    default: []
+analysis_driver:
+  description: Dakota analysis driver program
   value:
     type: choice
-    default: Mean
+    default: dakota_run_plugin
     choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-probability_levels1:
-  description:
-    Probabilities at which to estimate response values (a comma-delimited list)
+      - dakota_run_plugin
+      - dakota_run_component
+id_interface:
+  description: Name of the interface block
   value:
     type: string
-    default: ''
-    units: '-'
-response_levels1:
-  description:
-    Levels at which to estimate response PDF and CDF (a comma-delimited list)
-  value:
-    type: string
-    default: ''
-    units: '-'
+    default: CSDMS
 
-response_descriptor2:
-  description: Response variable name
+descriptors:
+  description:
+    Input variable name
   value:
-    type: dynamic_choice
+    type: list
     default:
-    units: '-'
-response_statistic2:
-  description: Statistic computed on response
-  value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-probability_levels2:
+lower_bounds:
   description:
-    Probabilities at which to estimate response values (a comma-delimited list)
+    Lower bound on values of study variable
   value:
-    type: string
-    default: ''
-    units: '-'
-response_levels2:
+    type: list
+    default: [0.0]
+upper_bounds:
   description:
-    Levels at which to estimate response PDF and CDF (a comma-delimited list)
+    Upper bound on values of study variable
   value:
-    type: string
-    default: ''
-    units: '-'
+    type: list
+    default: [1.0]
+means:
+  description:
+    Mean of the study variable distribution
+  value:
+    type: list
+    default: [0.0]
+std_deviations:
+  description:
+    Standard deviation of the study variable distribution
+  value:
+    type: list
+    default: [1.0]
 
-response_descriptor3:
-  description: Response variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic3:
-  description: Statistic computed on response
-  value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-probability_levels3:
+response_descriptors:
   description:
-    Probabilities at which to estimate response values (a comma-delimited list)
+    Response variable name
   value:
-    type: string
-    default: ''
-    units: '-'
-response_levels3:
+    type: list
+    default: []
+response_statistics:
   description:
-    Levels at which to estimate response PDF and CDF (a comma-delimited list)
+    Statistic computed on response
   value:
-    type: string
-    default: ''
-    units: '-'
+    type: list
+    default: ['mean']
+probability_levels:
+  description:
+    Probabilities at which to estimate response values
+  value:
+    type: list
+    default: [0.1, 0.5, 0.9]
+response_levels:
+  description:
+    Levels at which to estimate response PDF and CDF
+  value:
+    type: list
+    default: []
+response_files:
+  description: Model output files used for calculating response
+  value:
+    type: list
+    default: []
 
 sample_type:
   description:
@@ -238,7 +102,6 @@ sample_type:
     choices:
       - Random sampling
       - Latin hypercube sampling
-    units: '-'
 samples:
   description:
     Number of samples in experiment
@@ -248,7 +111,6 @@ samples:
     range:
       min: 1
       max: 1e6
-    units: '-'
 seed:
   description:
     Seed for random number generator (0 = randomly selected)
@@ -258,7 +120,6 @@ seed:
     range:
       min: 0
       max: 1e6
-    units: '-'
 variance_based_decomp:
   description:
     Activate global sensitivity analysis based on decomposition of response variance
@@ -268,7 +129,6 @@ variance_based_decomp:
     choices:
       - False
       - True
-    units: '-'
 variable_type:
   description:
     Variable type used in the experiment
@@ -278,4 +138,3 @@ variable_type:
     choices:
       - Uniform uncertain
       - Normal uncertain
-    units: '-'

--- a/.bmi/stoch_collocation/api.yaml
+++ b/.bmi/stoch_collocation/api.yaml
@@ -2,3 +2,4 @@ name: StochasticCollocation
 language: python
 package: dakotathon.bmi
 class: StochasticCollocation
+initialize_args: "config.yaml"

--- a/.bmi/stoch_collocation/api.yaml
+++ b/.bmi/stoch_collocation/api.yaml
@@ -2,4 +2,4 @@ name: StochasticCollocation
 language: python
 package: dakotathon.bmi
 class: StochasticCollocation
-initialize_args: "config.yaml"
+initialize_args: "dakota.yaml"

--- a/.bmi/stoch_collocation/config.yaml.tmpl
+++ b/.bmi/stoch_collocation/config.yaml.tmpl
@@ -1,77 +1,51 @@
 method: stoch_collocation
 
-analysis_driver: dakota_run_plugin
+analysis_driver: {analysis_driver}
 asynchronous: false
-auxiliary_files:
+auxiliary_files: {auxiliary_files}
 basis_polynomial_family: extended
 coefficient_estimation_approach: quadrature_order_sequence
-component: {component}          # set by hook
+component: {component}
 configuration_file: config.yaml
 convergence_tolerance:
 data_file: dakota.dat
-descriptors:
-- "{descriptor1}"
-- "{descriptor2}"
-- "{descriptor3}"
+descriptors: {descriptors}
 dimension_preference:
 evaluation_concurrency: 2
 gradients: no_gradients
 hessians: no_hessians
-id_interface: CSDMS
+id_interface: {id_interface} 
 initial_point:
 input_file: dakota.in
 interface: fork
-lower_bounds:
-- {lower_bound1}
-- {lower_bound2}
-- {lower_bound3}
+lower_bounds: {lower_bounds}
 max_iterations:
-means:
-- {mean1}
-- {mean2}
-- {mean3}
+means: {means}
 nested: false
 output_file: dakota.out
-probability_levels:
-- {probability_levels1}
-- {probability_levels2}
-- {probability_levels3}
+plugin: {plugin}
+probability_levels: {probability_levels}
 quadrature_order: {quadrature_order} 
-response_descriptors:
-- "{response_descriptor1}"
-- "{response_descriptor2}"
-- "{response_descriptor3}"
-response_files:
-response_levels:
-- {response_levels1}
-- {response_levels2}
-- {response_levels3}
-response_statistics:
-- "{response_statistic1}"
-- "{response_statistic2}"
-- "{response_statistic3}"
+response_descriptors: {response_descriptors}
+response_files: {response_files}
+response_levels: {response_levels}
+response_statistics: {response_statistics}
 responses: response_functions
 run_directory: .
 sample_type: "{sample_type}"
 samples: {samples}
 seed: {seed}
-std_deviations:
-- {std_deviation1}
-- {std_deviation2}
-- {std_deviation3}
-template_file: {template_file}  # set by hook
-upper_bounds:
-- {upper_bound1}
-- {upper_bound2}
-- {upper_bound3}
+std_deviations: {std_deviations}
+template_file: "{template_file}"
+upper_bounds: {upper_bounds}
 variables: "{variable_type}"
 variance_based_decomp: {variance_based_decomp}
 
 # Notes:
 # * For uniform_uncertain variables, ignore means and std_deviations.
-# * The values of response_levels and probability_levels need to be
-#   converted to lists.
-# * BMI handles auxiliary_files and response_files.
+# * The descriptors, lower_bounds, upper_bounds, means, std_deviations,
+#   probability_levels, response_levels, response_descriptors,
+#   and response_statistics parameters should be scalars or lists.
 # * coefficient_estimation_approach must be set, but the only option
 #   currently is quadrature_order_sequence.
 # * dimension_preference isn't implemented.

--- a/.bmi/stoch_collocation/dakota.yaml.tmpl
+++ b/.bmi/stoch_collocation/dakota.yaml.tmpl
@@ -1,4 +1,4 @@
-method: polynomial_chaos
+method: stoch_collocation
 
 analysis_driver: {analysis_driver}
 asynchronous: false
@@ -6,7 +6,7 @@ auxiliary_files: {auxiliary_files}
 basis_polynomial_family: extended
 coefficient_estimation_approach: quadrature_order_sequence
 component: {component}
-configuration_file: config.yaml
+configuration_file: dakota.yaml
 convergence_tolerance:
 data_file: dakota.dat
 descriptors: {descriptors}

--- a/.bmi/stoch_collocation/dakota.yaml.tmpl
+++ b/.bmi/stoch_collocation/dakota.yaml.tmpl
@@ -16,6 +16,7 @@ gradients: no_gradients
 hessians: no_hessians
 id_interface: {id_interface} 
 initial_point:
+initialize_args: {initialize_args}
 input_file: dakota.in
 interface: fork
 lower_bounds: {lower_bounds}

--- a/.bmi/stoch_collocation/dakota.yaml.tmpl
+++ b/.bmi/stoch_collocation/dakota.yaml.tmpl
@@ -31,7 +31,7 @@ response_files: {response_files}
 response_levels: {response_levels}
 response_statistics: {response_statistics}
 responses: response_functions
-run_directory: .
+run_directory: {run_directory}
 sample_type: "{sample_type}"
 samples: {samples}
 seed: {seed}

--- a/.bmi/stoch_collocation/parameters.yaml
+++ b/.bmi/stoch_collocation/parameters.yaml
@@ -1,233 +1,97 @@
-descriptor1:
-  description: Input variable name
+component:
+  description: Name of CSDMS component
   value:
-    type: dynamic_choice
+    type: string
     default:
-    units: '-'
-lower_bound1:
-  description: Lower bound on values of study variable
+plugin:
+  description: Name of model plugin
   value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-upper_bound1:
-  description: Upper bound on values of study variable
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-mean1:
-  description: Mean of the distribution
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-std_deviation1:
-  description: Standard deviation of the distribution
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: 1e-6
-      max: 1e6
-    units: '-'
-
-descriptor2:
-  description: Input variable name
-  value:
-    type: dynamic_choice
+    type: string
     default:
-    units: '-'
-lower_bound2:
-  description: Lower bound on values of study variable
+template_file:
+  description: Dakota template of model configuration file
   value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-upper_bound2:
-  description: Upper bound on values of study variable
+    type: string
+    default: 'config.yaml.dtmpl'
+auxiliary_files:
+  description: Additional model input files
   value:
-    type: float
-    default: 1.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-mean2:
-  description: Mean of the distribution
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-std_deviation2:
-  description: Standard deviation of the distribution
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: 1e-6
-      max: 1e6
-    units: '-'
-
-descriptor3:
-  description: Input variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-lower_bound3:
-  description: Lower bound on values of study variable
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-upper_bound3:
-  description: Upper bound on values of study variable
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-mean3:
-  description: Mean of the distribution
-  value:
-    type: float
-    default: 0.0
-    range:
-      min: -1e6
-      max: 1e6
-    units: '-'
-std_deviation3:
-  description: Standard deviation of the distribution
-  value:
-    type: float
-    default: 1.0
-    range:
-      min: 1e-6
-      max: 1e6
-    units: '-'
-
-response_descriptor1:
-  description: Response variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic1:
-  description: Statistic computed on response
+    type: list
+    default: []
+analysis_driver:
+  description: Dakota analysis driver program
   value:
     type: choice
-    default: Mean
+    default: dakota_run_plugin
     choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-probability_levels1:
-  description:
-    Probabilities at which to estimate response values (a comma-delimited list)
+      - dakota_run_plugin
+      - dakota_run_component
+id_interface:
+  description: Name of the interface block
   value:
     type: string
-    default: ''
-    units: '-'
-response_levels1:
-  description:
-    Levels at which to estimate response PDF and CDF (a comma-delimited list)
-  value:
-    type: string
-    default: ''
-    units: '-'
+    default: CSDMS
 
-response_descriptor2:
-  description: Response variable name
+descriptors:
+  description:
+    Input variable name
   value:
-    type: dynamic_choice
+    type: list
     default:
-    units: '-'
-response_statistic2:
-  description: Statistic computed on response
-  value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-probability_levels2:
+lower_bounds:
   description:
-    Probabilities at which to estimate response values (a comma-delimited list)
+    Lower bound on values of study variable
   value:
-    type: string
-    default: ''
-    units: '-'
-response_levels2:
+    type: list
+    default: [0.0]
+upper_bounds:
   description:
-    Levels at which to estimate response PDF and CDF (a comma-delimited list)
+    Upper bound on values of study variable
   value:
-    type: string
-    default: ''
-    units: '-'
+    type: list
+    default: [1.0]
+means:
+  description:
+    Mean of the study variable distribution
+  value:
+    type: list
+    default: [0.0]
+std_deviations:
+  description:
+    Standard deviation of the study variable distribution
+  value:
+    type: list
+    default: [1.0]
 
-response_descriptor3:
-  description: Response variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic3:
-  description: Statistic computed on response
-  value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-probability_levels3:
+response_descriptors:
   description:
-    Probabilities at which to estimate response values (a comma-delimited list)
+    Response variable name
   value:
-    type: string
-    default: ''
-    units: '-'
-response_levels3:
+    type: list
+    default: []
+response_statistics:
   description:
-    Levels at which to estimate response PDF and CDF (a comma-delimited list)
+    Statistic computed on response
   value:
-    type: string
-    default: ''
-    units: '-'
+    type: list
+    default: ['mean']
+probability_levels:
+  description:
+    Probabilities at which to estimate response values
+  value:
+    type: list
+    default: [0.1, 0.5, 0.9]
+response_levels:
+  description:
+    Levels at which to estimate response PDF and CDF
+  value:
+    type: list
+    default: []
+response_files:
+  description: Model output files used for calculating response
+  value:
+    type: list
+    default: []
 
 quadrature_order:
   description:
@@ -244,7 +108,6 @@ quadrature_order:
       - 6
       - 7
       - 8
-    units: '-'
 sample_type:
   description:
     Technique for choosing samples
@@ -254,7 +117,6 @@ sample_type:
     choices:
       - Random sampling
       - Latin hypercube sampling
-    units: '-'
 samples:
   description:
     Number of samples in experiment
@@ -264,7 +126,6 @@ samples:
     range:
       min: 1
       max: 1e6
-    units: '-'
 seed:
   description:
     Seed for random number generator (0 = randomly selected)
@@ -274,7 +135,6 @@ seed:
     range:
       min: 0
       max: 1e6
-    units: '-'
 variance_based_decomp:
   description:
     Activate global sensitivity analysis based on decomposition of response variance
@@ -284,7 +144,6 @@ variance_based_decomp:
     choices:
       - False
       - True
-    units: '-'
 variable_type:
   description:
     Variable type used in the experiment
@@ -294,4 +153,3 @@ variable_type:
     choices:
       - Uniform uncertain
       - Normal uncertain
-    units: '-'

--- a/.bmi/stoch_collocation/parameters.yaml
+++ b/.bmi/stoch_collocation/parameters.yaml
@@ -12,7 +12,7 @@ template_file:
   description: Dakota template of model configuration file
   value:
     type: string
-    default: 'config.yaml.dtmpl'
+    default: 'dakota.yaml.dtmpl'
 auxiliary_files:
   description: Additional model input files
   value:

--- a/.bmi/stoch_collocation/parameters.yaml
+++ b/.bmi/stoch_collocation/parameters.yaml
@@ -8,6 +8,11 @@ plugin:
   value:
     type: string
     default:
+run_directory:
+  description: Directory in which Dakota experiment is run
+  value:
+    type: string
+    default: '.'
 template_file:
   description: Dakota template of model configuration file
   value:

--- a/.bmi/stoch_collocation/parameters.yaml
+++ b/.bmi/stoch_collocation/parameters.yaml
@@ -36,6 +36,11 @@ id_interface:
   value:
     type: string
     default: CSDMS
+initialize_args:
+  description: Arguments passed to component initialize method
+  value:
+    type: string
+    default: ''
 
 descriptors:
   description:

--- a/.bmi/vector_parameter_study/api.yaml
+++ b/.bmi/vector_parameter_study/api.yaml
@@ -2,4 +2,4 @@ name: VectorParameterStudy
 language: python
 package: dakotathon.bmi
 class: VectorParameterStudy
-initialize_args: "config.yaml"
+initialize_args: "dakota.yaml"

--- a/.bmi/vector_parameter_study/api.yaml
+++ b/.bmi/vector_parameter_study/api.yaml
@@ -2,3 +2,4 @@ name: VectorParameterStudy
 language: python
 package: dakotathon.bmi
 class: VectorParameterStudy
+initialize_args: "config.yaml"

--- a/.bmi/vector_parameter_study/config.yaml.tmpl
+++ b/.bmi/vector_parameter_study/config.yaml.tmpl
@@ -1,19 +1,19 @@
 method: vector_parameter_study
 
-analysis_driver: dakota_run_plugin
+analysis_driver: {analysis_driver}
 asynchronous: false
-auxiliary_files:
-component: {component}          # set by hook
+auxiliary_files: {auxiliary_files}
+component: {component}
 configuration_file: config.yaml
 convergence_tolerance:
 data_file: dakota.dat
-descriptors: ["{descriptor1}", "{descriptor2}", "{descriptor3}",]
+descriptors: {descriptors}
 evaluation_concurrency: 2
-final_point: [{final_point1}, {final_point2}, {final_point3},]
+final_point: {final_point}
 gradients: no_gradients
 hessians: no_hessians
-id_interface: CSDMS
-initial_point: [{initial_point1}, {initial_point2}, {initial_point3},]
+id_interface: {id_interface}
+initial_point: {initial_point}
 input_file: dakota.in
 interface: fork
 lower_bounds:
@@ -21,15 +21,17 @@ max_iterations:
 means:
 n_steps: {n_steps}
 output_file: dakota.out
-response_descriptors: ["{response_descriptor1}", "{response_descriptor2}", "{response_descriptor3}",]
-response_files:
-response_statistics: ["{response_statistic1}", "{response_statistic2}", "{response_statistic3}",]
+plugin: {plugin}
+response_descriptors: {response_descriptors}
+response_files: {response_files}
+response_statistics: {response_statistics}
 responses: response_functions
 run_directory: .
 std_deviations:
-template_file: {template_file}  # set by hook
+template_file: "{template_file}"
 upper_bounds:
 variables: continuous_design
 
 # Notes:
-# * BMI handles auxiliary_files and response_files.
+# * The descriptors, final_point, initial_point, response_descriptors,
+#   and response_statistics parameters should be scalars or lists.

--- a/.bmi/vector_parameter_study/dakota.yaml.tmpl
+++ b/.bmi/vector_parameter_study/dakota.yaml.tmpl
@@ -26,7 +26,7 @@ response_descriptors: {response_descriptors}
 response_files: {response_files}
 response_statistics: {response_statistics}
 responses: response_functions
-run_directory: .
+run_directory: {run_directory}
 std_deviations:
 template_file: "{template_file}"
 upper_bounds:

--- a/.bmi/vector_parameter_study/dakota.yaml.tmpl
+++ b/.bmi/vector_parameter_study/dakota.yaml.tmpl
@@ -1,25 +1,26 @@
-method: multidim_parameter_study
+method: vector_parameter_study
 
 analysis_driver: {analysis_driver}
 asynchronous: false
-auxiliary_files:
+auxiliary_files: {auxiliary_files}
 component: {component}
-configuration_file: config.yaml
+configuration_file: dakota.yaml
 convergence_tolerance:
 data_file: dakota.dat
 descriptors: {descriptors}
 evaluation_concurrency: 2
+final_point: {final_point}
 gradients: no_gradients
 hessians: no_hessians
-id_interface: {id_interface} 
-initial_point:
+id_interface: {id_interface}
+initial_point: {initial_point}
 input_file: dakota.in
 interface: fork
-lower_bounds: {lower_bounds}
+lower_bounds:
 max_iterations:
 means:
+n_steps: {n_steps}
 output_file: dakota.out
-partitions: {partitions}
 plugin: {plugin}
 response_descriptors: {response_descriptors}
 response_files: {response_files}
@@ -28,10 +29,9 @@ responses: response_functions
 run_directory: .
 std_deviations:
 template_file: "{template_file}"
-upper_bounds: {upper_bound}
+upper_bounds:
 variables: continuous_design
 
 # Notes:
-# * The descriptors, initial_point, lower_bounds, partitions,
-#   response_descriptors, response_statistics, and upper_bounds
-#   parameters should be scalars or lists.
+# * The descriptors, final_point, initial_point, response_descriptors,
+#   and response_statistics parameters should be scalars or lists.

--- a/.bmi/vector_parameter_study/dakota.yaml.tmpl
+++ b/.bmi/vector_parameter_study/dakota.yaml.tmpl
@@ -14,6 +14,7 @@ gradients: no_gradients
 hessians: no_hessians
 id_interface: {id_interface}
 initial_point: {initial_point}
+initialize_args: {initialize_args}
 input_file: dakota.in
 interface: fork
 lower_bounds:

--- a/.bmi/vector_parameter_study/parameters.yaml
+++ b/.bmi/vector_parameter_study/parameters.yaml
@@ -1,120 +1,72 @@
-descriptor1:
+component:
+  description: Name of CSDMS component
+  value:
+    type: string
+    default:
+plugin:
+  description: Name of model plugin
+  value:
+    type: string
+    default:
+template_file:
+  description: Dakota template of model configuration file
+  value:
+    type: string
+    default: 'config.yaml.dtmpl'
+auxiliary_files:
+  description: Additional model input files
+  value:
+    type: list
+    default: []
+analysis_driver:
+  description: Dakota analysis driver program
+  value:
+    type: choice
+    default: dakota_run_plugin
+    choices:
+      - dakota_run_plugin
+      - dakota_run_component
+id_interface:
+  description: Name of the interface block
+  value:
+    type: string
+    default: CSDMS
+
+descriptors:
   description: Input variable name
   value:
-    type: dynamic_choice
-    default:
-    units: '-'
-initial_point1:
+    type: list
+    default: []
+initial_point:
   description: Start point for study variable
   value:
-    type: float
-    default: 0.0
-    units: '-'
-final_point1:
+    type: list
+    default: [0.0]
+final_point:
   description: End point for study variable
   value:
-    type: float
-    default: 1.0
-    units: '-'
-descriptor2:
-  description: Input variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-initial_point2:
-  description: Start point for study variable
-  value:
-    type: float
-    default: 0.0
-    units: '-'
-final_point2:
-  description: End point for study variable
-  value:
-    type: float
-    default: 1.0
-    units: '-'
-descriptor3:
-  description: Input variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-initial_point3:
-  description: Start point for study variable
-  value:
-    type: float
-    default: 0.0
-    units: '-'
-final_point3:
-  description: End point for study variable
-  value:
-    type: float
-    default: 1.0
-    units: '-'
+    type: list
+    default: [1.0]
 n_steps:
   description: Number of steps to take along vector
   value:
     type: int
-    default: 4
+    default: 5
     range:
       min: 1
       max: 1e3
-    units: '-'
-response_descriptor1:
+response_descriptors:
   description: Response variable name
   value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic1:
+    type: list
+    default: []
+response_statistics:
   description: Statistic computed on response
   value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-response_descriptor2:
-  description: Response variable name
+    type: list
+    default: ['mean']
+response_files:
+  description: Model output files used for calculating response
   value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic2:
-  description: Statistic computed on response
-  value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
-response_descriptor3:
-  description: Response variable name
-  value:
-    type: dynamic_choice
-    default:
-    units: '-'
-response_statistic3:
-  description: Statistic computed on response
-  value:
-    type: choice
-    default: Mean
-    choices:
-      - Mean
-      - Median
-      - Sum
-      - Standard deviation
-      - Maximum
-      - Minimum
-    units: '-'
+    type: list
+    default: []

--- a/.bmi/vector_parameter_study/parameters.yaml
+++ b/.bmi/vector_parameter_study/parameters.yaml
@@ -12,7 +12,7 @@ template_file:
   description: Dakota template of model configuration file
   value:
     type: string
-    default: 'config.yaml.dtmpl'
+    default: 'dakota.yaml.dtmpl'
 auxiliary_files:
   description: Additional model input files
   value:

--- a/.bmi/vector_parameter_study/parameters.yaml
+++ b/.bmi/vector_parameter_study/parameters.yaml
@@ -8,6 +8,11 @@ plugin:
   value:
     type: string
     default:
+run_directory:
+  description: Directory in which Dakota experiment is run
+  value:
+    type: string
+    default: '.'
 template_file:
   description: Dakota template of model configuration file
   value:

--- a/.bmi/vector_parameter_study/parameters.yaml
+++ b/.bmi/vector_parameter_study/parameters.yaml
@@ -36,6 +36,11 @@ id_interface:
   value:
     type: string
     default: CSDMS
+initialize_args:
+  description: Arguments passed to component initialize method
+  value:
+    type: string
+    default: ''
 
 descriptors:
   description: Input variable name

--- a/README.md
+++ b/README.md
@@ -8,48 +8,45 @@
 
 # CSDMS Dakota interface
 
-The CSDMS Dakota interface provides
+The CSDMS Dakota interface (CDI) provides
 a [Basic Model Interface](http://dx.doi.org/10.1016/j.cageo.2012.04.002)
-and a Python API for the [Dakota](https://dakota.sandia.gov/)
-iterative systems analysis toolkit.
+and a Python API for a subset of the methods
+included in the [Dakota](https://dakota.sandia.gov/)
+iterative systems analysis toolkit,
+including:
+
+* [vector_parameter_study](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-vector_parameter_study.html),
+* [centered_parameter_study](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-centered_parameter_study.html),
+* [multidim_parameter_study](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-multidim_parameter_study.html),
+* [sampling](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-sampling.html),
+* [polynomial_chaos](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-polynomial_chaos.html), and
+* [stoch_collocation](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-stoch_collocation.html).
+
 This is currently alpha-level software
 supported on Linux and Mac OSX.
 
 ## Installation
 
-Install the CSDMS Dakota interface with:
+Install the CDI into a Anaconda Python distribution with
+
+    $ conda install -c csdms dakotathon
+
+or install from source with
 
 	$ git clone https://github.com/csdms/dakota.git
 	$ cd dakota
 	$ python setup.py install
 
-The CSDMS Dakota interface requires Dakota.
+The CDI requires Dakota.
 Follow the instructions on the Dakota website
 for [downloading](https://dakota.sandia.gov/download.html) and
 [installing](https://dakota.sandia.gov/content/install-linux-macosx)
 a precompiled Dakota binary for your system.
 Dakota version 6.1 is supported by the CSDMS Dakota interface.
 
-HydroTrend is the only CSDMS model currently supported
-in the CSDMS Dakota interface.
-On Mac OS X,
-install HydroTrend through [Homebrew](http://brew.sh/):
+## Execution: standalone
 
-	$ brew tap csdms/models
-	$ brew install hydrotrend
-
-On Linux,
-build HydroTrend from source:
-
-	$ git clone https://github.com/csdms-contrib/hydrotrend.git
-	$ mkdir -p hydrotrend/build && cd hydrotrend/build
-	$ cmake ..
-	$ make
-	$ make install
-
-## Execution
-
-Import the CSDMS Dakota interface into a Python session with:
+Import the CDI into a Python session with:
 
 	>>> from dakotathon import Dakota
 
@@ -57,18 +54,6 @@ Create a `Dakota` instance,
 specifying a Dakota analysis method:
 
 	>>> d = Dakota(method='vector_parameter_study')
-
-Currently,
-six Dakota methods
-
-* [vector_parameter_study](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-vector_parameter_study.html)
-* [centered_parameter_study](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-centered_parameter_study.html)
-* [multidim_parameter_study](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-multidim_parameter_study.html)
-* [sampling](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-sampling.html)
-* [polynomial_chaos](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-polynomial_chaos.html)
-* [stoch_collocation](https://dakota.sandia.gov/sites/default/files/docs/6.1/html-ref/method-stoch_collocation.html)
-
-are supported.
 
 To run a sample case,
 create a Dakota input file
@@ -85,7 +70,8 @@ and
 in the current directory.
 
 For more in-depth examples of using the CSDMS Dakota interface,
-see the Jupyter Notebooks in the [examples](./examples) directory
+see the Jupyter Notebooks
+in the [examples](./examples) directory
 of this repository.
 
 
@@ -101,3 +87,89 @@ in your session before calling the `run` method with:
 ```
 
 See https://github.com/csdms/dakota/issues/17 for more information.
+
+## Execution: in PyMT
+
+The CDI can also be called as a component in a WMT execution server
+where [PyMT](https://github.com/csdms/pymt) has been installed.
+For example,
+to perform a centered parameter study on the Hydrotrend component,
+start with imports:
+
+```python
+import os
+from pymt.components import CenteredParameterStudy, Hydrotrend
+from dakotathon.utils import configure_parameters
+```
+
+then create instances of the Hydrotrend and Dakota components:
+
+```python
+h, c = Hydrotrend(), CenteredParameterStudy()
+```
+
+Next,
+set up a dict of parameters for the experiment:
+
+```python
+parameters = {
+  'component': type(c).__name__,
+  'run_duration': 365,               # days
+  'auxiliary_files': 'HYDRO0.HYPS',  # the default Waipaoa hypsometry
+  'descriptors': ['starting_mean_annual_temperature',
+                  'total_annual_precipitation'],
+  'initial_point': [15.0, 2.0],
+  'steps_per_variable': [2, 5],
+  'step_vector': [2.5, 0.2],
+  'response_descriptors': ['channel_exit_water_sediment~suspended__mass_flow_rate',
+                           'channel_exit_water__volume_flow_rate'],
+  'response_statistics': ['median', 'mean']
+}
+```
+
+and use a helper function
+to format the parameters for Dakota and Hydrotrend:
+
+```python
+cparameters, hparameters = configure_parameters(parameters)
+```
+
+Set up the Hydrotrend component:
+
+```python
+cparameters['run_directory'] = h.setup(os.getcwd(), **hparameters)
+```
+
+Create the Dakota template file from the Hydrotrend input file:
+
+```python
+cfg_file = 'HYDRO.IN'  # get from pymt eventually
+dtmpl_file = cfg_file + '.dtmpl'
+os.rename(cfg_file, dtmpl_file)
+cparameters['template_file'] = dtmpl_file
+```
+
+Set up the Dakota component:
+
+```python
+c.setup(dparameters['run_directory'], **cparameters)
+```
+
+then initialize, run, and finalize the Dakota component:
+
+```python
+c.initialize('dakota.yaml')
+c.update()
+c.finalize()
+```
+
+Dakota output is written to two files,
+**dakota.out** (run information)
+and
+**dakota.dat** (tabular output),
+in the current directory.
+
+For more in-depth examples of using the CDI with PyMT,
+see the Python scripts
+in the [examples](./examples) directory
+of this repository.

--- a/dakotathon/dakota.py
+++ b/dakotathon/dakota.py
@@ -14,7 +14,7 @@ class Dakota(Experiment):
 
     def __init__(self,
                  run_directory=os.getcwd(),
-                 configuration_file=os.path.abspath('config.yaml'),
+                 configuration_file=os.path.abspath('dakota.yaml'),
                  input_file='dakota.in',
                  output_file='dakota.out',
                  template_file=None,
@@ -34,7 +34,7 @@ class Dakota(Experiment):
             is placed (default is the current directory).
         configuration_file : str, optional
             A Dakota instance serialized to a YAML file (default is
-            **config.yaml**).
+            **dakota.yaml**).
         input_file : str, optional
             Name of Dakota input file (default is **dakota.in**)
         output_file : str, optional
@@ -97,7 +97,7 @@ class Dakota(Experiment):
         Parameters
         ----------
         value : str
-          The new file path (default is 'config.yaml').
+          The new file path (default is 'dakota.yaml').
 
         """
         if not os.path.isabs(value):
@@ -187,7 +187,7 @@ class Dakota(Experiment):
         experiment:
 
         >>> d = Dakota(method='vector_parameter_study')
-        >>> d.serialize('config.yaml')
+        >>> d.serialize('dakota.yaml')
 
         """
         from .utils import get_attributes

--- a/dakotathon/experiment.py
+++ b/dakotathon/experiment.py
@@ -184,8 +184,8 @@ class Experiment(object):
     def _get_subpackage_namespace(self, subpackage):
         return os.path.splitext(self.__module__)[0] + '.' + subpackage
 
-    def _import(self, subpackage, module, **kwargs):
-        namespace = self._get_subpackage_namespace(subpackage) + '.' + module
+    def _import(self, _subpackage, _module, **kwargs):
+        namespace = self._get_subpackage_namespace(_subpackage) + '.' + _module
         module = importlib.import_module(namespace)
         cls = getattr(module, module.classname)
         return cls(**kwargs)

--- a/dakotathon/experiment.py
+++ b/dakotathon/experiment.py
@@ -13,6 +13,7 @@ class Experiment(object):
 
     def __init__(self,
                  component=None,
+                 plugin=None,
                  environment='environment',
                  method='vector_parameter_study',
                  variables='continuous_design',
@@ -29,7 +30,12 @@ class Experiment(object):
         ----------
         component : str, optional
             Name of CSDMS component which Dakota is analyzing (default
-            is None).
+            is None). The `component` and `plugin` parameters are
+            exclusive.
+        plugin : str, optional
+            Name of a plugin model which Dakota is analyzing (default
+            is None). The `component` and `plugin` parameters are
+            exclusive.
         environment : str, optional
             Type of environment used in Dakota experiment (default is
             'environment').
@@ -60,8 +66,26 @@ class Experiment(object):
 
         """
         self.component = component
+        self.plugin = plugin
+
+        if (self.component and self.plugin) is not None:
+            err_msg = 'The component and plugin attributes are exclusive.'
+            raise AttributeError(err_msg)
+
         if self.component is not None:
             interface = 'fork'
+            try:
+                kwargs['analysis_driver']
+            except KeyError:
+                kwargs['analysis_driver'] = 'dakota_run_component'
+
+        if self.plugin is not None:
+            interface = 'fork'
+            try:
+                kwargs['analysis_driver']
+            except KeyError:
+                kwargs['analysis_driver'] = 'dakota_run_plugin'
+
         if method == 'multidim_parameter_study':
             try:
                 kwargs['lower_bounds']

--- a/dakotathon/interface/fork.py
+++ b/dakotathon/interface/fork.py
@@ -28,7 +28,6 @@ class Fork(InterfaceBase):
         """
         InterfaceBase.__init__(self, **kwargs)
         self.interface = self.__module__.rsplit('.')[-1]
-        self.analysis_driver = 'dakota_run_plugin'
         self._configuration_file = os.path.abspath('config.yaml')
         self.parameters_file = 'params.in'
         self.results_file = 'results.out'

--- a/dakotathon/interface/fork.py
+++ b/dakotathon/interface/fork.py
@@ -28,7 +28,7 @@ class Fork(InterfaceBase):
         """
         InterfaceBase.__init__(self, **kwargs)
         self.interface = self.__module__.rsplit('.')[-1]
-        self._configuration_file = os.path.abspath('config.yaml')
+        self._configuration_file = os.path.abspath('dakota.yaml')
         self.parameters_file = 'params.in'
         self.results_file = 'results.out'
 

--- a/dakotathon/method/centered_parameter_study.py
+++ b/dakotathon/method/centered_parameter_study.py
@@ -2,6 +2,7 @@
 """Implementation of a Dakota centered parameter study."""
 
 from .base import MethodBase
+from ..utils import to_iterable
 
 
 classname = 'CenteredParameterStudy'
@@ -83,12 +84,14 @@ class CenteredParameterStudy(MethodBase):
 
         """
         s = MethodBase.__str__(self)
+        steps_per_variable = to_iterable(self.steps_per_variable)
+        step_vector = to_iterable(self.step_vector)
         s += '    steps_per_variable ='
-        for step in self.steps_per_variable:
+        for step in steps_per_variable:
             s += ' {}'.format(step)
         s += '\n' \
             + '    step_vector ='
-        for step in self.step_vector:
+        for step in step_vector:
             s += ' {}'.format(step)
         s += '\n\n'
         return(s)

--- a/dakotathon/method/multidim_parameter_study.py
+++ b/dakotathon/method/multidim_parameter_study.py
@@ -2,6 +2,7 @@
 """Implementation of a Dakota multidim parameter study."""
 
 from .base import MethodBase
+from ..utils import to_iterable
 
 
 classname = 'MultidimParameterStudy'
@@ -61,8 +62,9 @@ class MultidimParameterStudy(MethodBase):
 
         """
         s = MethodBase.__str__(self)
+        partitions = to_iterable(self.partitions)
         s += '    partitions ='
-        for p in self.partitions:
+        for p in partitions:
             s += ' {}'.format(p)
         s += '\n\n'
         return(s)

--- a/dakotathon/method/vector_parameter_study.py
+++ b/dakotathon/method/vector_parameter_study.py
@@ -2,6 +2,7 @@
 """Implementation of a Dakota vector parameter study."""
 
 from .base import MethodBase
+from ..utils import to_iterable
 
 
 classname = 'VectorParameterStudy'
@@ -83,8 +84,9 @@ class VectorParameterStudy(MethodBase):
 
         """
         s = MethodBase.__str__(self)
+        final_point = to_iterable(self.final_point)
         s += '    final_point ='
-        for pt in self.final_point:
+        for pt in final_point:
             s += ' {}'.format(pt)
         s += '\n' \
             + '    num_steps = {}\n\n'.format(self.n_steps)

--- a/dakotathon/responses/response_functions.py
+++ b/dakotathon/responses/response_functions.py
@@ -1,6 +1,7 @@
 """Implementation of the Dakota response_function response type."""
 
 from .base import ResponsesBase
+from ..utils import to_iterable
 
 
 classname = 'ResponseFunctions'
@@ -91,11 +92,11 @@ class ResponseFunctions(ResponsesBase):
         dakotathon.responses.base.ResponsesBase.__str__
 
         """
-        n_descriptors = len(self.response_descriptors)
+        descriptors = to_iterable(self.response_descriptors)
         s = ResponsesBase.__str__(self)
-        s += '  response_functions = {}\n'.format(n_descriptors)
+        s += '  response_functions = {}\n'.format(len(descriptors))
         s += '    response_descriptors ='
-        for rd in self.response_descriptors:
+        for rd in descriptors:
             s += ' {!r}'.format(rd)
         s += '\n' \
              + '  {}\n'.format(self.gradients) \

--- a/dakotathon/run_component.py
+++ b/dakotathon/run_component.py
@@ -7,7 +7,7 @@ import subprocess
 import importlib
 import numpy as np
 from .utils import (get_configuration_file, deserialize,
-                    compute_statistic, write_results)
+                    compute_statistic, write_results, to_iterable)
 
 
 component_script = 'dakota_run_component'
@@ -19,7 +19,7 @@ class ComponentOutput(object):
 
     def __init__(self, component, var_names):
         self.component = component
-        self.var_names = var_names
+        self.var_names = to_iterable(var_names)
         for var in self.var_names:
             setattr(self, var, [])
 

--- a/dakotathon/run_component.py
+++ b/dakotathon/run_component.py
@@ -43,7 +43,6 @@ class RunComponent(object):
         self.results_file = results_file
         self.component = None
         self.input_file = None
-        self.n_responses = 0
         self.output = None
         self.results = []
 
@@ -64,7 +63,6 @@ class RunComponent(object):
         root_dir, self.input_file = os.path.split(input_file)
         for fname in self.config['auxiliary_files']:
             shutil.copy(os.path.join(root_dir, fname), os.getcwd())
-        self.n_responses = len(self.config['response_descriptors'])
         self.output = ComponentOutput(self.component,
                                       self.config['response_descriptors'])
 
@@ -76,7 +74,7 @@ class RunComponent(object):
         self.component.finalize()
 
     def calculate(self):
-        for i in range(self.n_responses):
+        for i in range(len(self.config['response_descriptors'])):
             desc = self.config['response_descriptors'][i]
             stat = self.config['response_statistics'][i]
             r = compute_statistic(stat, self.output.get_value(desc))

--- a/dakotathon/run_component.py
+++ b/dakotathon/run_component.py
@@ -56,11 +56,12 @@ class RunComponent(object):
         self.component = cls()
 
     def setup(self):
-        self.input_file, _ = os.path.splitext(self.config['template_file'])
+        input_file, _ = os.path.splitext(self.config['template_file'])
         subprocess.call(['dprepro', self.params_file,
                          self.config['template_file'],
-                         self.input_file])
-        shutil.copy(self.input_file, os.getcwd())
+                         input_file])
+        shutil.move(input_file, os.getcwd())
+        self.input_file = os.path.basename(input_file)
         self.n_responses = len(self.config['response_descriptors'])
         self.output = ComponentOutput(self.component,
                                       self.config['response_descriptors'])

--- a/dakotathon/run_component.py
+++ b/dakotathon/run_component.py
@@ -42,7 +42,6 @@ class RunComponent(object):
         self.params_file = params_file
         self.results_file = results_file
         self.component = None
-        self.input_file = None
         self.output = None
         self.results = []
 
@@ -55,19 +54,19 @@ class RunComponent(object):
         self.component = cls()
 
     def setup(self):
+        shutil.copy(os.path.join(self.config['run_directory'],
+                                 self.config['template_file']), os.getcwd())
         input_file, _ = os.path.splitext(self.config['template_file'])
         subprocess.call(['dprepro', self.params_file,
                          self.config['template_file'],
                          input_file])
-        shutil.move(input_file, os.getcwd())
-        root_dir, self.input_file = os.path.split(input_file)
         for fname in self.config['auxiliary_files']:
-            shutil.copy(os.path.join(root_dir, fname), os.getcwd())
+            shutil.copy(os.path.join(self.config['run_directory'], fname), os.getcwd())
         self.output = ComponentOutput(self.component,
                                       self.config['response_descriptors'])
 
     def run(self):
-        self.component.initialize(self.input_file)
+        self.component.initialize(self.config['initialize_args'])
         while self.component.get_current_time() < self.component.get_end_time():
             self.component.update()
             self.output.update()

--- a/dakotathon/run_component.py
+++ b/dakotathon/run_component.py
@@ -61,7 +61,9 @@ class RunComponent(object):
                          self.config['template_file'],
                          input_file])
         shutil.move(input_file, os.getcwd())
-        self.input_file = os.path.basename(input_file)
+        root_dir, self.input_file = os.path.split(input_file)
+        for fname in self.config['auxiliary_files']:
+            shutil.copy(os.path.join(root_dir, fname), os.getcwd())
         self.n_responses = len(self.config['response_descriptors'])
         self.output = ComponentOutput(self.component,
                                       self.config['response_descriptors'])

--- a/dakotathon/run_component.py
+++ b/dakotathon/run_component.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+"""Defines the `dakota_run_component` console script."""
+
+import os
+import shutil
+import subprocess
+import importlib
+import numpy as np
+from .utils import (get_configuration_file, deserialize,
+                    compute_statistic, write_results)
+
+
+component_script = 'dakota_run_component'
+component_path = 'pymt.components'
+
+
+def run_component(params_file, results_file):
+    """Brokers communication between Dakota and a model through files.
+
+    Parameters
+    ----------
+    params_file : str
+      The path to the parameters file created by Dakota.
+    results_file : str
+      The path the results file returned to Dakota.
+
+    Notes
+    -----
+    This console script provides a generic *analysis driver* for a
+    Dakota experiment. At each evaluation step, Dakota calls this
+    script with two arguments, the names of the parameters and results files:
+
+    1. The parameters file provides information on the current Dakota
+       evaluation step, including the names and values of model
+       variables and their responses. It also includes, as the
+       *analysis component*, the name of a configuration file that
+       stores information about the setup of the experiment, including
+       the name of the model to call, input files, output file(s) to
+       examine, and the statistic to apply to the output file(s).
+
+    2. The results file contains model output values in a format
+       specified by the Dakota documentation.
+
+    Once the model is identified, an interface is created to perform
+    three steps: preprocessing, execution, and postprocessing. In the
+    preprocessing step, information from the configuration file is
+    transferred to the component. In the execution step, the component
+    is called, using the information passed from Dakota. In the
+    postprocessing step, output from the component is read, and a
+    single statistic (e.g., mean, median, max, etc.) is applied to
+    it. This number, one for each response, is returned to Dakota
+    through the results file, ending the Dakota evaluation step.
+
+    """
+    config_file = get_configuration_file(params_file)
+    config = deserialize(config_file)
+
+    try:
+        module = importlib.import_module(component_path)
+        cls = getattr(module, config['component'])
+        component = cls()
+    except (ImportError, AttributeError) as e:
+        print 'Error:', e
+        print 'Component cannot be created.'
+
+    # Convert the Dakota template file to a model config file
+    # with `dprepro`.
+    input_file, ext = os.path.splitext(config['template_file'])
+    subprocess.call(['dprepro', params_file, config['template_file'], input_file])
+    shutil.copy(input_file, os.getcwd())
+
+    # Using BMI methods, run the model and collect outputs.
+    output = {}
+    for key in config['response_descriptors']:
+        output[key] = []
+    component.initialize(input_file)
+    while component.get_current_time() < component.get_end_time():
+        component.update()
+        for key in config['response_descriptors']:
+            output[key].append(component.get_value(key))  # held in memory!
+    component.finalize()
+    
+    # Calculate the response statistic and write the Dakota results file.
+    values, labels = [], []
+    for i in range(len(config['response_descriptors'])):
+        descriptor = config['response_descriptors'][i]
+        statistic = config['response_statistics'][i]
+        r = compute_statistic(statistic, output[descriptor])
+        values.append(r)
+        labels.append(descriptor)
+    write_results(results_file, values, labels)
+
+
+def main():
+    """Handle arguments to the `dakota_run_component` console script."""
+    import argparse
+    from . import __version__
+
+    parser = argparse.ArgumentParser(
+        description="A generic analysis driver for a Dakota experiment.")
+    parser.add_argument("parameters_file",
+                        help="parameters file from Dakota")
+    parser.add_argument("results_file",
+                        help="results file to Dakota")
+    parser.add_argument('--version', action='version',
+                        version=component_script + ' ' + __version__)
+    args = parser.parse_args()
+
+    run_component(args.parameters_file, args.results_file)
+
+if __name__ == '__main__':
+    main()

--- a/dakotathon/run_plugin.py
+++ b/dakotathon/run_plugin.py
@@ -50,20 +50,20 @@ def run_plugin(params_file, results_file):
     config_file = get_configuration_file(params_file)
     config = deserialize(config_file)
 
-    _module = importlib.import_module(_plugins_path + config['component'])
+    _module = importlib.import_module(_plugins_path + config['plugin'])
     if _module.is_installed():
         _class = getattr(_module, _module.classname)
-        component = _class()
+        model = _class()
     else:
-        raise NameError('Component cannot be created.')
+        raise NameError('Model cannot be created.')
 
-    # Set up the simulation, call the component, calculate the
-    # response statistic for the simulation, write the output to the
-    # Dakota results file.
-    component.setup(config)
-    component.call()
-    component.calculate()
-    component.write(params_file, results_file)
+    # Set up the simulation, call the model, calculate the response
+    # statistic for the simulation, write the output to the Dakota
+    # results file.
+    model.setup(config)
+    model.call()
+    model.calculate()
+    model.write(params_file, results_file)
 
 
 def main():

--- a/dakotathon/tests/data/config.yaml
+++ b/dakotathon/tests/data/config.yaml
@@ -2,7 +2,6 @@ analysis_driver: dakota_run_plugin
 asynchronous: false
 auxiliary_files:
 - /Users/mpiper/scratch/fun-with-dakota/hydrotrend-new/HYDRO0.HYPS
-component: hydrotrend
 configuration_file: /Users/mpiper/scratch/fun-with-dakota/hydrotrend-new/config.yaml
 data_file: dakota.dat
 descriptors:
@@ -25,6 +24,7 @@ method: vector_parameter_study
 n_steps: 5
 output_file: dakota.out
 parameters_file: params.in
+plugin: hydrotrend
 response_descriptors:
 - Qs_median
 - Q_mean

--- a/dakotathon/tests/data/dakota.yaml
+++ b/dakotathon/tests/data/dakota.yaml
@@ -2,7 +2,7 @@ analysis_driver: dakota_run_plugin
 asynchronous: false
 auxiliary_files:
 - /Users/mpiper/scratch/fun-with-dakota/hydrotrend-new/HYDRO0.HYPS
-configuration_file: /Users/mpiper/scratch/fun-with-dakota/hydrotrend-new/config.yaml
+configuration_file: /Users/mpiper/scratch/fun-with-dakota/hydrotrend-new/dakota.yaml
 data_file: dakota.dat
 descriptors:
 - starting_mean_annual_temperature

--- a/dakotathon/tests/data/default_cps_config.yaml
+++ b/dakotathon/tests/data/default_cps_config.yaml
@@ -1,29 +1,40 @@
 analysis_driver: rosenbrock
+asynchronous: false
+auxiliary_files: []
 component: null
-configuration_file: /Users/mpiper/scratch/config.yaml
+configuration_file: /home/csdms/wmt/_testing/_test/config.yaml
+convergence_tolerance: null
 data_file: dakota.dat
-initial_point: !!python/tuple
-- 0.0
-- 0.0
-input_files: !!python/tuple []
+descriptors:
+- x1
+- x2
+evaluation_concurrency: 2
+gradients: no_gradients
+hessians: no_hessians
+id_interface: CSDMS
+initial_point:
+- -0.3
+- 0.2
+input_file: dakota.in
 interface: direct
-is_objective_function: false
+lower_bounds: null
+max_iterations: null
 method: centered_parameter_study
-parameters_file: params.in
-responses: !!python/tuple
+output_file: dakota.out
+plugin: null
+response_descriptors:
 - y1
-response_files: !!python/tuple []
-response_statistics: !!python/tuple []
-results_file: results.out
-run_directory: /Users/mpiper/scratch
-step_vector: !!python/tuple
+response_files: []
+response_statistics:
+- mean
+responses: response_functions
+run_directory: /home/csdms/wmt/_testing/_test
+step_vector:
 - 0.4
 - 0.5
-steps_per_variable: !!python/tuple
+steps_per_variable:
 - 5
 - 4
 template_file: null
-variables: !!python/tuple
-- x1
-- x2
-variable_type: continuous_design
+upper_bounds: null
+variables: continuous_design

--- a/dakotathon/tests/data/default_cps_dakota.yaml
+++ b/dakotathon/tests/data/default_cps_dakota.yaml
@@ -1,9 +1,8 @@
 analysis_driver: rosenbrock
 asynchronous: false
 auxiliary_files: []
-basis_polynomial_family: extended
 component: null
-configuration_file: /home/csdms/wmt/_testing/_test/config.yaml
+configuration_file: /home/csdms/wmt/_testing/_test/dakota.yaml
 convergence_tolerance: null
 data_file: dakota.dat
 descriptors:
@@ -20,25 +19,22 @@ input_file: dakota.in
 interface: direct
 lower_bounds: null
 max_iterations: null
-method: sampling
+method: centered_parameter_study
 output_file: dakota.out
 plugin: null
-probability_levels:
-- 0.1
-- 0.5
-- 0.9
 response_descriptors:
 - y1
 response_files: []
-response_levels: []
 response_statistics:
 - mean
 responses: response_functions
 run_directory: /home/csdms/wmt/_testing/_test
-sample_type: random
-samples: 10
-seed: null
+step_vector:
+- 0.4
+- 0.5
+steps_per_variable:
+- 5
+- 4
 template_file: null
 upper_bounds: null
 variables: continuous_design
-variance_based_decomp: false

--- a/dakotathon/tests/data/default_mps_config.yaml
+++ b/dakotathon/tests/data/default_mps_config.yaml
@@ -2,7 +2,7 @@ analysis_driver: rosenbrock
 asynchronous: false
 auxiliary_files: []
 component: null
-configuration_file: /Users/mpiper/tmp/config.yaml
+configuration_file: /home/csdms/wmt/_testing/_test/config.yaml
 convergence_tolerance: null
 data_file: dakota.dat
 descriptors:
@@ -24,13 +24,14 @@ output_file: dakota.out
 partitions:
 - 10
 - 8
+plugin: null
 response_descriptors:
 - y1
 response_files: []
 response_statistics:
 - mean
 responses: response_functions
-run_directory: /Users/mpiper/tmp
+run_directory: /home/csdms/wmt/_testing/_test
 template_file: null
 upper_bounds:
 - 2.0

--- a/dakotathon/tests/data/default_mps_dakota.yaml
+++ b/dakotathon/tests/data/default_mps_dakota.yaml
@@ -2,29 +2,28 @@ analysis_driver: rosenbrock
 asynchronous: false
 auxiliary_files: []
 component: null
-configuration_file: /home/csdms/wmt/_testing/_test/config.yaml
+configuration_file: /home/csdms/wmt/_testing/_test/dakota.yaml
 convergence_tolerance: null
 data_file: dakota.dat
 descriptors:
 - x1
 - x2
 evaluation_concurrency: 2
-final_point:
-- 1.1
-- 1.3
 gradients: no_gradients
 hessians: no_hessians
 id_interface: CSDMS
-initial_point:
-- -0.3
-- 0.2
+initial_point: null
 input_file: dakota.in
 interface: direct
-lower_bounds: null
+lower_bounds:
+- -2.0
+- -2.0
 max_iterations: null
-method: vector_parameter_study
-n_steps: 10
+method: multidim_parameter_study
 output_file: dakota.out
+partitions:
+- 10
+- 8
 plugin: null
 response_descriptors:
 - y1
@@ -34,5 +33,7 @@ response_statistics:
 responses: response_functions
 run_directory: /home/csdms/wmt/_testing/_test
 template_file: null
-upper_bounds: null
+upper_bounds:
+- 2.0
+- 2.0
 variables: continuous_design

--- a/dakotathon/tests/data/default_sampling_config.yaml
+++ b/dakotathon/tests/data/default_sampling_config.yaml
@@ -1,8 +1,10 @@
 analysis_driver: rosenbrock
 asynchronous: false
 auxiliary_files: []
+basis_polynomial_family: extended
 component: null
-configuration_file: /Users/mpiper/projects/dakota/csdms/dakota/tests/config.yaml
+configuration_file: /home/csdms/wmt/_testing/_test/config.yaml
+convergence_tolerance: null
 data_file: dakota.dat
 descriptors:
 - x1
@@ -11,26 +13,32 @@ evaluation_concurrency: 2
 gradients: no_gradients
 hessians: no_hessians
 id_interface: CSDMS
-initial_point: null
-input_file: rosenbrock_sampling.in
+initial_point:
+- -0.3
+- 0.2
+input_file: dakota.in
 interface: direct
-lower_bounds:
-- -2.0
-- -2.0
+lower_bounds: null
+max_iterations: null
 method: sampling
 output_file: dakota.out
+plugin: null
+probability_levels:
+- 0.1
+- 0.5
+- 0.9
 response_descriptors:
 - y1
 response_files: []
+response_levels: []
 response_statistics:
 - mean
 responses: response_functions
-run_directory: /Users/mpiper/projects/dakota/csdms/dakota/tests
+run_directory: /home/csdms/wmt/_testing/_test
 sample_type: random
 samples: 10
 seed: null
 template_file: null
-upper_bounds:
-- 2.0
-- 2.0
-variables: uniform_uncertain
+upper_bounds: null
+variables: continuous_design
+variance_based_decomp: false

--- a/dakotathon/tests/data/default_sampling_dakota.yaml
+++ b/dakotathon/tests/data/default_sampling_dakota.yaml
@@ -1,8 +1,9 @@
 analysis_driver: rosenbrock
 asynchronous: false
 auxiliary_files: []
+basis_polynomial_family: extended
 component: null
-configuration_file: /home/csdms/wmt/_testing/_test/config.yaml
+configuration_file: /home/csdms/wmt/_testing/_test/dakota.yaml
 convergence_tolerance: null
 data_file: dakota.dat
 descriptors:
@@ -19,22 +20,25 @@ input_file: dakota.in
 interface: direct
 lower_bounds: null
 max_iterations: null
-method: centered_parameter_study
+method: sampling
 output_file: dakota.out
 plugin: null
+probability_levels:
+- 0.1
+- 0.5
+- 0.9
 response_descriptors:
 - y1
 response_files: []
+response_levels: []
 response_statistics:
 - mean
 responses: response_functions
 run_directory: /home/csdms/wmt/_testing/_test
-step_vector:
-- 0.4
-- 0.5
-steps_per_variable:
-- 5
-- 4
+sample_type: random
+samples: 10
+seed: null
 template_file: null
 upper_bounds: null
 variables: continuous_design
+variance_based_decomp: false

--- a/dakotathon/tests/data/default_vps_config.yaml
+++ b/dakotathon/tests/data/default_vps_config.yaml
@@ -2,7 +2,8 @@ analysis_driver: rosenbrock
 asynchronous: false
 auxiliary_files: []
 component: null
-configuration_file: /Users/mpiper/scratch/fun-with-dakota/config.yaml
+configuration_file: /home/csdms/wmt/_testing/_test/config.yaml
+convergence_tolerance: null
 data_file: dakota.dat
 descriptors:
 - x1
@@ -20,16 +21,18 @@ initial_point:
 input_file: dakota.in
 interface: direct
 lower_bounds: null
+max_iterations: null
 method: vector_parameter_study
 n_steps: 10
 output_file: dakota.out
+plugin: null
 response_descriptors:
 - y1
 response_files: []
 response_statistics:
 - mean
 responses: response_functions
-run_directory: /Users/mpiper/scratch/fun-with-dakota
+run_directory: /home/csdms/wmt/_testing/_test
 template_file: null
 upper_bounds: null
 variables: continuous_design

--- a/dakotathon/tests/data/default_vps_dakota.yaml
+++ b/dakotathon/tests/data/default_vps_dakota.yaml
@@ -2,28 +2,29 @@ analysis_driver: rosenbrock
 asynchronous: false
 auxiliary_files: []
 component: null
-configuration_file: /home/csdms/wmt/_testing/_test/config.yaml
+configuration_file: /home/csdms/wmt/_testing/_test/dakota.yaml
 convergence_tolerance: null
 data_file: dakota.dat
 descriptors:
 - x1
 - x2
 evaluation_concurrency: 2
+final_point:
+- 1.1
+- 1.3
 gradients: no_gradients
 hessians: no_hessians
 id_interface: CSDMS
-initial_point: null
+initial_point:
+- -0.3
+- 0.2
 input_file: dakota.in
 interface: direct
-lower_bounds:
-- -2.0
-- -2.0
+lower_bounds: null
 max_iterations: null
-method: multidim_parameter_study
+method: vector_parameter_study
+n_steps: 10
 output_file: dakota.out
-partitions:
-- 10
-- 8
 plugin: null
 response_descriptors:
 - y1
@@ -33,7 +34,5 @@ response_statistics:
 responses: response_functions
 run_directory: /home/csdms/wmt/_testing/_test
 template_file: null
-upper_bounds:
-- 2.0
-- 2.0
+upper_bounds: null
 variables: continuous_design

--- a/dakotathon/tests/data/params.in
+++ b/dakotathon/tests/data/params.in
@@ -8,5 +8,5 @@
                                           1 DVV_1:starting_mean_annual_temperature
                                           2 DVV_2:total_annual_precipitation
                                           1 analysis_components
-                                config.yaml AC_1:dakota_run_plugin
+                                dakota.yaml AC_1:dakota_run_plugin
                                           1 eval_id

--- a/dakotathon/tests/data/vector_parameter_study.in
+++ b/dakotathon/tests/data/vector_parameter_study.in
@@ -16,7 +16,7 @@ variables
 interface
   fork
   analysis_driver = 'dakota_run_plugin'
-  analysis_components = 'config.yaml'
+  analysis_components = 'dakota.yaml'
   parameters_file = 'params.in'
   results_file = 'results.out'
   work_directory

--- a/dakotathon/tests/test_dakota.py
+++ b/dakotathon/tests/test_dakota.py
@@ -25,10 +25,10 @@ input_file, \
     restart_file = ['dakota.' + ext for ext in ('in', 'out', 'dat', 'rst')]
 alt_input_file = 'alt.in'
 known_file = os.path.join(data_dir, 'default_vps_dakota.in')
-known_config_file = os.path.join(data_dir, 'default_vps_config.yaml')
-default_config_file = os.path.join(os.getcwd(), 'config.yaml')
+known_config_file = os.path.join(data_dir, 'default_vps_dakota.yaml')
+default_config_file = os.path.join(os.getcwd(), 'dakota.yaml')
 tmp_files = [input_file, alt_input_file, output_file, data_file,
-             restart_file, 'config.yaml']
+             restart_file, 'dakota.yaml']
 
 # Fixtures -------------------------------------------------------------
 

--- a/dakotathon/tests/test_experiment.py
+++ b/dakotathon/tests/test_experiment.py
@@ -45,6 +45,48 @@ def test_component_sets_interface_type():
     assert_is_instance(e.interface, Fork)
 
 
+def test_component_sets_analysis_driver():
+    """Test that setting component sets the analysis driver."""
+    component = 'hydrotrend'
+    e = Experiment(component=component)
+    assert_equal(e.interface.analysis_driver, 'dakota_run_component')
+
+
+def test_get_plugin():
+    """Test getting the plugin attribute."""
+    assert_is_none(x.plugin)
+
+
+def test_set_plugin():
+    """Test setting the plugin attribute."""
+    e = Experiment()
+    plugin = 'hydrotrend'
+    e.plugin = plugin
+    assert_equal(e.plugin, plugin)
+
+
+def test_plugin_sets_interface_type():
+    """Test that setting plugin sets fork interface."""
+    from .test_interface_fork import Fork
+    plugin = 'hydrotrend'
+    e = Experiment(plugin=plugin)
+    assert_is_instance(e.interface, Fork)
+
+
+def test_plugin_sets_analysis_driver():
+    """Test that setting plugin sets the analysis driver."""
+    plugin = 'hydrotrend'
+    e = Experiment(plugin=plugin)
+    assert_equal(e.interface.analysis_driver, 'dakota_run_plugin')
+
+
+@raises(AttributeError)
+def test_setting_component_and_plugin():
+    """Test that setting component and plugin raises exception."""
+    component = plugin = 'hydrotrend'
+    e = Experiment(component=component, plugin=plugin)
+
+
 def test_multidim_parameter_study_uses_bounds():
     """Test that the multidim parameter study uses bounds."""
     e = Experiment(method='multidim_parameter_study')

--- a/dakotathon/tests/test_interface_fork.py
+++ b/dakotathon/tests/test_interface_fork.py
@@ -38,9 +38,9 @@ def test_interface_attribute():
     assert_equal(f.interface, 'fork')
 
 
-def test_analysis_driver_attribute():
-    """Test value of the analysis_driver attribute."""
-    assert_equal(f.analysis_driver, 'dakota_run_plugin')
+# def test_analysis_driver_attribute():
+#     """Test value of the analysis_driver attribute."""
+#     assert_equal(f.analysis_driver, 'dakota_run_plugin')
 
 
 def test_config_file_path():

--- a/dakotathon/tests/test_interface_fork.py
+++ b/dakotathon/tests/test_interface_fork.py
@@ -7,7 +7,7 @@ from .test_interface_base import default_str_lines
 
 
 run_dir = os.getcwd()
-config_file = os.path.join(run_dir, 'config.yaml')
+config_file = os.path.join(run_dir, 'dakota.yaml')
 
 
 def setup_module():

--- a/dakotathon/tests/test_plugin_hydrotrend.py
+++ b/dakotathon/tests/test_plugin_hydrotrend.py
@@ -22,7 +22,7 @@ from . import start_dir, data_dir
 # Global variables -----------------------------------------------------
 
 run_dir = os.getcwd()
-config_file = os.path.join(data_dir, 'config.yaml')
+config_file = os.path.join(data_dir, 'dakota.yaml')
 params_file = os.path.join(data_dir, 'params.in')
 known_results_file = os.path.join(data_dir, 'results.out')
 results_file = 'results.out'

--- a/dakotathon/tests/test_plugin_hydrotrend_run.py
+++ b/dakotathon/tests/test_plugin_hydrotrend_run.py
@@ -22,8 +22,8 @@ from . import start_dir, data_dir
 # Global variables -----------------------------------------------------
 
 run_dir = os.getcwd()
-config_file = os.path.join(run_dir, 'config.yaml')
-known_config_file = os.path.join(data_dir, 'config.yaml')
+config_file = os.path.join(run_dir, 'dakota.yaml')
+known_config_file = os.path.join(data_dir, 'dakota.yaml')
 # known_dat_file = os.path.join(data_dir, 'dakota.dat')
 
 # Fixtures -------------------------------------------------------------

--- a/dakotathon/tests/test_plugin_hydrotrend_run.py
+++ b/dakotathon/tests/test_plugin_hydrotrend_run.py
@@ -66,7 +66,7 @@ def teardown_module():
 @with_setup(setup, teardown)
 def test_run_by_setting_attributes():
     """Test running a HydroTrend simulation."""
-    d = Dakota(method='vector_parameter_study', component='hydrotrend')
+    d = Dakota(method='vector_parameter_study', plugin='hydrotrend')
     d.template_file = os.path.join(data_dir, 'HYDRO.IN.dtmpl')
     d.auxiliary_files = os.path.join(data_dir, 'HYDRO0.HYPS')
     d.variables.descriptors = ['starting_mean_annual_temperature',

--- a/dakotathon/tests/test_rosenbrock_sampling.py
+++ b/dakotathon/tests/test_rosenbrock_sampling.py
@@ -10,8 +10,8 @@ from . import data_dir
 run_dir = os.getcwd()
 input_file = os.path.join(run_dir, 'dakota.in')
 known_input_file = os.path.join(data_dir, 'rosenbrock_sampling.in')
-config_file = os.path.join(run_dir, 'config.yaml')
-known_config_file = os.path.join(data_dir, 'default_sampling_config.yaml')
+config_file = os.path.join(run_dir, 'dakota.yaml')
+known_config_file = os.path.join(data_dir, 'default_sampling_dakota.yaml')
 
 
 def setup_module():

--- a/dakotathon/tests/test_run_component.py
+++ b/dakotathon/tests/test_run_component.py
@@ -3,8 +3,10 @@
 import os
 import sys
 import shutil
-from nose.tools import raises, with_setup
-from dakotathon.run_component import run_component, main
+from nose.tools import (raises, with_setup, assert_is_instance,
+                        assert_true)
+from dakotathon.run_component import (run_component, main,
+                                      ComponentOutput, RunComponent)
 from dakotathon.dakota import Dakota
 from . import start_dir, data_dir
 
@@ -63,3 +65,28 @@ def test_main_no_args():
     """Tests main() fails without args."""
     sys.argv = []
     main()
+
+
+def test_ComponentOutput_init1():
+    """Test ComponentOutput initializes with string input"""
+    x = ComponentOutput(None, 'foo')
+    assert_is_instance(x, ComponentOutput)
+
+
+def test_ComponentOutput_init2():
+    """Test ComponentOutput initializes with list input"""
+    x = ComponentOutput(None, ['foo', 'bar'])
+    assert_is_instance(x, ComponentOutput)
+
+
+def test_ComponentOutput_get_value():
+    """Test ComponentOutput.get_value() returns list"""
+    var_name = 'foo'
+    x = ComponentOutput(None, var_name)
+    assert_true(type(x.get_value(var_name)) is list)
+
+
+# def test_RunComponent_init():
+#     """Test RunComponent initializes"""
+#     x = RunComponent(params_file, results_file)
+#     assert_is_instance(x, RunComponent)

--- a/dakotathon/tests/test_run_component.py
+++ b/dakotathon/tests/test_run_component.py
@@ -49,21 +49,12 @@ def test_run_component_unknown_config_file():
     run_component(params_file, results_file)
 
 
-@raises(AttributeError)
+@raises(ImportError)
 @with_setup(setup, teardown)
 def test_run_component_unknown_module():
     """Tests run_component() fails with unknown module."""
     d.component = 'foo'
     d.serialize(local_config_file)
-    run_component(params_file, results_file)
-
-
-@raises(TypeError)
-@with_setup(setup, teardown)
-def test_run_component_uninstalled_module():
-    """Tests run_component() fails with module that's not installed."""
-    d.serialize(local_config_file)
-    os.environ['PATH'] = '.'
     run_component(params_file, results_file)
 
 

--- a/dakotathon/tests/test_run_component.py
+++ b/dakotathon/tests/test_run_component.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import shutil
+from nose.tools import raises, with_setup
+from dakotathon.run_component import run_component, main
+from dakotathon.dakota import Dakota
+from . import start_dir, data_dir
+
+
+run_dir = os.getcwd()
+local_config_file = 'config.yaml'
+config_file = os.path.join(data_dir, local_config_file)
+local_params_file = 'params.in'
+params_file = os.path.join(data_dir, local_params_file)
+results_file = 'results.out'
+
+
+def setup_module():
+    """Called before any tests are performed."""
+    print('\n*** ' + __name__)
+
+
+def setup():
+    """Called at start of any test using it @with_setup()"""
+    global d
+    d = Dakota.from_file_like(config_file)
+
+
+def teardown():
+    """Called at end of any test using it @with_setup()"""
+    if os.path.exists(results_file):
+        os.remove(results_file)
+    if os.path.exists(local_config_file):
+        os.remove(local_config_file)
+    if os.path.exists(local_params_file):
+        os.remove(local_params_file)
+
+
+def teardown_module():
+    """Called after all tests have completed."""
+    pass
+
+
+@raises(IOError)
+def test_run_component_unknown_config_file():
+    """Tests run_component() fails with unknown config file."""
+    run_component(params_file, results_file)
+
+
+@raises(AttributeError)
+@with_setup(setup, teardown)
+def test_run_component_unknown_module():
+    """Tests run_component() fails with unknown module."""
+    d.component = 'foo'
+    d.serialize(local_config_file)
+    run_component(params_file, results_file)
+
+
+@raises(TypeError)
+@with_setup(setup, teardown)
+def test_run_component_uninstalled_module():
+    """Tests run_component() fails with module that's not installed."""
+    d.serialize(local_config_file)
+    os.environ['PATH'] = '.'
+    run_component(params_file, results_file)
+
+
+@raises(IndexError)
+def test_main_no_args():
+    """Tests main() fails without args."""
+    sys.argv = []
+    main()

--- a/dakotathon/tests/test_run_component.py
+++ b/dakotathon/tests/test_run_component.py
@@ -10,7 +10,7 @@ from . import start_dir, data_dir
 
 
 run_dir = os.getcwd()
-local_config_file = 'config.yaml'
+local_config_file = 'dakota.yaml'
 config_file = os.path.join(data_dir, local_config_file)
 local_params_file = 'params.in'
 params_file = os.path.join(data_dir, local_params_file)

--- a/dakotathon/tests/test_run_component.py
+++ b/dakotathon/tests/test_run_component.py
@@ -49,13 +49,13 @@ def test_run_component_unknown_config_file():
     run_component(params_file, results_file)
 
 
-@raises(ImportError)
-@with_setup(setup, teardown)
-def test_run_component_unknown_module():
-    """Tests run_component() fails with unknown module."""
-    d.component = 'foo'
-    d.serialize(local_config_file)
-    run_component(params_file, results_file)
+# @raises(ImportError)
+# @with_setup(setup, teardown)
+# def test_run_component_unknown_module():
+#     """Tests run_component() fails with unknown module."""
+#     d.component = 'foo'
+#     d.serialize(local_config_file)
+#     run_component(params_file, results_file)
 
 
 @raises(IndexError)

--- a/dakotathon/tests/test_run_plugin.py
+++ b/dakotathon/tests/test_run_plugin.py
@@ -80,7 +80,7 @@ def test_run_plugin_unknown_config_file():
 @with_setup(setup, teardown)
 def test_run_plugin_unknown_module():
     """Tests run_plugin() fails with unknown module."""
-    d.method.component = 'foo'
+    d.plugin = 'foo'
     d.serialize(local_config_file)
     run_plugin(params_file, results_file)
 

--- a/dakotathon/tests/test_run_plugin.py
+++ b/dakotathon/tests/test_run_plugin.py
@@ -24,7 +24,7 @@ from . import start_dir, data_dir
 # Global variables -----------------------------------------------------
 
 run_dir = os.getcwd()
-local_config_file = 'config.yaml'
+local_config_file = 'dakota.yaml'
 config_file = os.path.join(data_dir, local_config_file)
 local_params_file = 'params.in'
 params_file = os.path.join(data_dir, local_params_file)

--- a/dakotathon/tests/test_utils.py
+++ b/dakotathon/tests/test_utils.py
@@ -161,20 +161,6 @@ def test_configure_parameters_fails_without_descriptors():
     r = configure_parameters(params)
 
 
-@raises(KeyError)
-def test_configure_parameters_fails_without_response_descriptors():
-    """Test that configure_parameters fails without response_descriptors."""
-    params = {'descriptors': 'foo'}
-    r = configure_parameters(params)
-
-
-@raises(KeyError)
-def test_configure_parameters_fails_without_response_statistics():
-    """Test that configure_parameters fails without response_statistics."""
-    params = {'descriptors': 'foo', 'response_descriptors': 'bar'}
-    r = configure_parameters(params)
-
-
 def test_configure_parameters_sets_plugin_and_component():
     """Test that configure_parameters sets analysis_driver for component."""
     params = {'descriptors': 'foo', 'response_descriptors': 'bar',

--- a/dakotathon/tests/test_utils.py
+++ b/dakotathon/tests/test_utils.py
@@ -18,7 +18,7 @@ from . import start_dir, data_dir
 parameters_file = os.path.join(data_dir, 'params.in')
 results_file = 'results.out'
 response_labels = ['Qs_median', 'Q_mean']
-config_file = os.path.join(data_dir, 'config.yaml')
+config_file = os.path.join(data_dir, 'dakota.yaml')
 plugin = 'hydrotrend'
 
 # Fixtures -------------------------------------------------------------

--- a/dakotathon/tests/test_utils.py
+++ b/dakotathon/tests/test_utils.py
@@ -126,9 +126,8 @@ def test_compute_statistic_nonumeric_array():
     r = compute_statistic(stat, arr)
 
 
-@raises(TypeError)
 def test_write_results_scalar_input():
-    """Test the write_results function fails with scalar inputs."""
+    """Test the write_results function works with scalar inputs."""
     values = 1.0
     labels = 'foo'
     r = write_results(results_file, values, labels)

--- a/dakotathon/tests/test_utils.py
+++ b/dakotathon/tests/test_utils.py
@@ -8,7 +8,7 @@
 # Mark Piper (mark.piper@colorado.edu)
 
 import os
-from nose.tools import (raises, assert_equal, assert_false,
+from nose.tools import (raises, assert_equal, assert_false, assert_true,
                         assert_is_none)
 from dakotathon.utils import *
 from . import start_dir, data_dir
@@ -132,3 +132,24 @@ def test_write_results_scalar_input():
     values = 1.0
     labels = 'foo'
     r = write_results(results_file, values, labels)
+
+
+def test_to_iterable_with_scalar():
+    """Test that to_iterable returns a tuple with scalar input."""
+    value = 'foo'
+    r = to_iterable(value)
+    assert_true(type(r) is tuple)
+
+
+def test_to_iterable_with_tuple():
+    """Test that to_iterable returns original tuple with tuple input."""
+    value = ('foo',)
+    r = to_iterable(value)
+    assert_true(r is value)
+
+
+def test_to_iterable_with_list():
+    """Test that to_iterable returns original list with list input."""
+    value = ['foo']
+    r = to_iterable(value)
+    assert_true(r is value)

--- a/dakotathon/tests/test_utils.py
+++ b/dakotathon/tests/test_utils.py
@@ -19,7 +19,7 @@ parameters_file = os.path.join(data_dir, 'params.in')
 results_file = 'results.out'
 response_labels = ['Qs_median', 'Q_mean']
 config_file = os.path.join(data_dir, 'config.yaml')
-component = 'hydrotrend'
+plugin = 'hydrotrend'
 
 # Fixtures -------------------------------------------------------------
 
@@ -94,7 +94,7 @@ def test_get_configuration_file_unknown_file():
 def test_deserialize():
     """Test the deserialize function."""
     config = deserialize(config_file)
-    assert_equal(component, config['component'])
+    assert_equal(plugin, config['plugin'])
 
 
 @raises(IOError)

--- a/dakotathon/tests/test_utils.py
+++ b/dakotathon/tests/test_utils.py
@@ -152,3 +152,63 @@ def test_to_iterable_with_list():
     value = ['foo']
     r = to_iterable(value)
     assert_true(r is value)
+
+
+@raises(KeyError)
+def test_configure_parameters_fails_without_descriptors():
+    """Test that configure_parameters fails without descriptors."""
+    params = {}
+    r = configure_parameters(params)
+
+
+@raises(KeyError)
+def test_configure_parameters_fails_without_response_descriptors():
+    """Test that configure_parameters fails without response_descriptors."""
+    params = {'descriptors': 'foo'}
+    r = configure_parameters(params)
+
+
+@raises(KeyError)
+def test_configure_parameters_fails_without_response_statistics():
+    """Test that configure_parameters fails without response_statistics."""
+    params = {'descriptors': 'foo', 'response_descriptors': 'bar'}
+    r = configure_parameters(params)
+
+
+def test_configure_parameters_sets_plugin_and_component():
+    """Test that configure_parameters sets analysis_driver for component."""
+    params = {'descriptors': 'foo', 'response_descriptors': 'bar',
+              'response_statistics': 'baz'}
+    updated, subs = configure_parameters(params)
+    assert_equal(updated['component'], '')
+    assert_equal(updated['plugin'], '')
+
+
+def test_configure_parameters_return_values():
+    """Test configure_parameters return values."""
+    params = {'descriptors': 'foo', 'response_descriptors': 'bar',
+              'response_statistics': 'baz'}
+    updated, subs = configure_parameters(params)
+    assert_equal(updated['component'], '')
+    assert_equal(updated['plugin'], '')
+
+
+def test_configure_parameters_sets_analysis_driver_component():
+    """Test that configure_parameters sets analysis_driver for component."""
+    params = {'descriptors': 'foo', 'response_descriptors': 'bar',
+              'response_statistics': 'baz'}
+    params['component'] = 'model'
+    r = configure_parameters(params)
+    assert_equal(type(r), tuple)
+    assert_equal(type(r[0]), dict)
+    assert_equal(type(r[1]), dict)
+
+
+def test_configure_parameters_sets_analysis_driver_plugin():
+    """Test that configure_parameters sets analysis_driver for plugin."""
+    params = {'descriptors': 'foo', 'response_descriptors': 'bar',
+              'response_statistics': 'baz'}
+    params['plugin'] = 'model'
+    updated, subs = configure_parameters(params)
+    assert_equal(updated['analysis_driver'], 'dakota_run_plugin')
+    assert_equal(updated['component'], '')

--- a/dakotathon/utils.py
+++ b/dakotathon/utils.py
@@ -217,3 +217,48 @@ def to_iterable(x):
         return x
     else:
         return (x,)
+
+
+def configure_parameters(params):
+    """Preprocess Dakota parameters prior to committing to a config file.
+
+    Parameters
+    ----------
+    params : dict
+      Configuration parameters for a Dakota experiment that map to the
+      items in the Dakota configuration file, **dakota.yaml**.
+
+    Returns
+    -------
+    (dict, dict)
+      An updated dict of Dakota configuration parameters, and a dict
+      of substitutions used to create the Dakota template ("dtmpl")
+      file.
+
+    """
+    try:
+        params['component']
+    except KeyError:
+        try:
+            params['plugin']
+        except KeyError:
+            params['component'] = params['plugin'] = ''
+        else:
+            params['analysis_driver'] = 'dakota_run_plugin'
+            params['component'] = ''
+    else:
+        params['analysis_driver'] = 'dakota_run_component'
+        params['plugin'] = ''
+
+    to_check = ['descriptors',
+                'response_descriptors',
+                'response_statistics']
+    for item in to_check:
+        if isinstance(params[item], basestring):
+            params[item] = [params[item]]
+
+    subs = {}
+    for item in params['descriptors']:
+        subs[item] = '{' + item + '}'
+
+    return params, subs

--- a/dakotathon/utils.py
+++ b/dakotathon/utils.py
@@ -264,5 +264,9 @@ def configure_parameters(params):
     subs = {}
     for item in params['descriptors']:
         subs[item] = '{' + item + '}'
+    try:
+        subs['run_duration'] = params['run_duration']
+    except KeyError:
+        pass
 
     return params, subs

--- a/dakotathon/utils.py
+++ b/dakotathon/utils.py
@@ -6,6 +6,7 @@ import subprocess
 import re
 import yaml
 import numpy as np
+import collections
 
 
 def is_dakota_installed():
@@ -192,11 +193,27 @@ def write_results(results_file, values, labels):
     arr_labels = np.asarray(labels)
     results = np.column_stack((arr_values, arr_labels))
     np.savetxt(results_file, results, delimiter="\t", fmt='%s')
-            
 
-def to_iterable(value):
-    """Convert a scalar value to a tuple."""
-    iterable_value = value
-    if not isinstance(value, (tuple, list)):
-        iterable_value = value,
-    return iterable_value
+
+def to_iterable(x):
+    """Get an iterable version of an input.
+
+    Parameters
+    ----------
+    x
+      Anything.
+
+    Returns
+    -------
+    If the input isn't iterable, or is a string, then a tuple; else,
+    the input.
+
+    Notes
+    -----
+    Courtesy http://stackoverflow.com/a/6711233/1563298
+
+    """
+    if isinstance(x, collections.Iterable) and not isinstance(x, basestring):
+        return x
+    else:
+        return (x,)

--- a/dakotathon/utils.py
+++ b/dakotathon/utils.py
@@ -255,8 +255,11 @@ def configure_parameters(params):
                 'response_statistics',
                 'auxiliary_files',]
     for item in to_check:
-        if isinstance(params[item], basestring):
-            params[item] = [params[item]]
+        try:
+            if isinstance(params[item], basestring):
+                params[item] = [params[item]]
+        except KeyError:
+            pass
 
     subs = {}
     for item in params['descriptors']:

--- a/dakotathon/utils.py
+++ b/dakotathon/utils.py
@@ -191,3 +191,11 @@ def write_results(results_file, values, labels):
     with open(results_file, 'w') as fp:
         for i in range(len(values)):
             fp.write('{0}\t{1}\n'.format(values[i], labels[i]))
+
+
+def to_iterable(value):
+    """Convert a scalar value to a tuple."""
+    iterable_value = value
+    if not isinstance(value, (tuple, list)):
+        iterable_value = value,
+    return iterable_value

--- a/dakotathon/utils.py
+++ b/dakotathon/utils.py
@@ -252,7 +252,8 @@ def configure_parameters(params):
 
     to_check = ['descriptors',
                 'response_descriptors',
-                'response_statistics']
+                'response_statistics',
+                'auxiliary_files',]
     for item in to_check:
         if isinstance(params[item], basestring):
             params[item] = [params[item]]

--- a/dakotathon/utils.py
+++ b/dakotathon/utils.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import re
 import yaml
+import numpy as np
 
 
 def is_dakota_installed():
@@ -171,7 +172,6 @@ def compute_statistic(statistic, array):
       The value of the computed statistic.
 
     """
-    import numpy as np
     return np.__getattribute__(statistic)(array)
 
 
@@ -188,10 +188,11 @@ def write_results(results_file, values, labels):
       A list of labels to attach to the values.
 
     """
-    with open(results_file, 'w') as fp:
-        for i in range(len(values)):
-            fp.write('{0}\t{1}\n'.format(values[i], labels[i]))
-
+    arr_values = np.asarray(values)
+    arr_labels = np.asarray(labels)
+    results = np.column_stack((arr_values, arr_labels))
+    np.savetxt(results_file, results, delimiter="\t", fmt='%s')
+            
 
 def to_iterable(value):
     """Convert a scalar value to a tuple."""

--- a/dakotathon/variables/base.py
+++ b/dakotathon/variables/base.py
@@ -1,6 +1,7 @@
 """An abstract base class for all Dakota variable types."""
 
 from abc import ABCMeta, abstractmethod
+from ..utils import to_iterable
 
 
 class VariablesBase(object):
@@ -50,10 +51,10 @@ class VariablesBase(object):
 
     def __str__(self):
         """Define the variables block of a Dakota input file."""
+        descriptors = to_iterable(self.descriptors)
         s = 'variables\n' \
-            + '  {0} = {1}\n'.format(self.variables,
-                                    len(self.descriptors))
+            + '  {0} = {1}\n'.format(self.variables, len(descriptors))
         s += '    descriptors ='
-        for vd in self.descriptors:
+        for vd in descriptors:
             s += ' {!r}'.format(vd)
         return(s)

--- a/dakotathon/variables/continuous_design.py
+++ b/dakotathon/variables/continuous_design.py
@@ -1,6 +1,7 @@
 """Implementation of a Dakota continous design variable."""
 
 from .base import VariablesBase
+from ..utils import to_iterable
 
 
 classname = 'ContinuousDesign'
@@ -134,19 +135,22 @@ class ContinuousDesign(VariablesBase):
         """
         s = VariablesBase.__str__(self)
         if self.initial_point is not None:
+            initial_point = to_iterable(self.initial_point)
             s += '\n' \
                  + '    initial_point ='
-            for pt in self.initial_point:
+            for pt in initial_point:
                 s += ' {}'.format(pt)
         if self.lower_bounds is not None:
+            lower_bounds = to_iterable(self.lower_bounds)
             s += '\n' \
                  + '    lower_bounds ='
-            for b in self.lower_bounds:
+            for b in lower_bounds:
                 s += ' {}'.format(b)
         if self.upper_bounds is not None:
+            upper_bounds = to_iterable(self.upper_bounds)
             s += '\n' \
                  + '    upper_bounds ='
-            for b in self.upper_bounds:
+            for b in upper_bounds:
                 s += ' {}'.format(b)
         s += '\n\n'
         return(s)

--- a/dakotathon/variables/normal_uncertain.py
+++ b/dakotathon/variables/normal_uncertain.py
@@ -1,6 +1,7 @@
 """Implementation of a Dakota normal uncertain variable."""
 
 from .base import VariablesBase
+from ..utils import to_iterable
 
 
 classname = 'NormalUncertain'
@@ -183,29 +184,34 @@ class NormalUncertain(VariablesBase):
         """
         s = VariablesBase.__str__(self)
         if self.means is not None:
+            means = to_iterable(self.means)
             s += '\n' \
                  + '    means ='
-            for m in self.means:
+            for m in means:
                 s += ' {}'.format(m)
         if self.std_deviations is not None:
+            std_deviations = to_iterable(self.std_deviations)
             s += '\n' \
                  + '    std_deviations ='
-            for m in self.std_deviations:
+            for m in std_deviations:
                 s += ' {}'.format(m)
         if self.lower_bounds is not None:
+            lower_bounds = to_iterable(self.lower_bounds)
             s += '\n' \
                  + '    lower_bounds ='
-            for b in self.lower_bounds:
+            for b in lower_bounds:
                 s += ' {}'.format(b)
         if self.upper_bounds is not None:
+            upper_bounds = to_iterable(self.upper_bounds)
             s += '\n' \
                  + '    upper_bounds ='
-            for b in self.upper_bounds:
+            for b in upper_bounds:
                 s += ' {}'.format(b)
         if self.initial_point is not None:
+            initial_point = to_iterable(self.initial_point)
             s += '\n' \
                  + '    initial_point ='
-            for pt in self.initial_point:
+            for pt in initial_point:
                 s += ' {}'.format(pt)
         s += '\n\n'
         return(s)

--- a/dakotathon/variables/uniform_uncertain.py
+++ b/dakotathon/variables/uniform_uncertain.py
@@ -1,6 +1,7 @@
 """Implementation of a Dakota uniform uncertain variable."""
 
 from .base import VariablesBase
+from ..utils import to_iterable
 
 
 classname = 'UniformUncertain'
@@ -132,19 +133,22 @@ class UniformUncertain(VariablesBase):
         """
         s = VariablesBase.__str__(self)
         if self.lower_bounds is not None:
+            lower_bounds = to_iterable(self.lower_bounds)
             s += '\n' \
                  + '    lower_bounds ='
-            for b in self.lower_bounds:
+            for b in lower_bounds:
                 s += ' {}'.format(b)
         if self.upper_bounds is not None:
+            upper_bounds = to_iterable(self.upper_bounds)
             s += '\n' \
                  + '    upper_bounds ='
-            for b in self.upper_bounds:
+            for b in upper_bounds:
                 s += ' {}'.format(b)
         if self.initial_point is not None:
+            initial_point = to_iterable(self.initial_point)
             s += '\n' \
                  + '    initial_point ='
-            for pt in self.initial_point:
+            for pt in initial_point:
                 s += ' {}'.format(pt)
         s += '\n\n'
         return(s)

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,15 +13,17 @@ and select one of the Notebooks to run.
 
 The scripts
 
-* **pymt-frostnumbermodel-vector-parameter-study.py** and
-* **pymt-frostnumbermodel-multidim-parameter-study.py**
+* **pymt-frostnumbermodel-vector-parameter-study.py**,
+* **pymt-frostnumbermodel-multidim-parameter-study.py**, and
+* **pymt-hydrotrend-centered-parameter-study.py**
 
 demonstrate how the CDI can be called as a component
 using [PyMT](https://github.com/csdms/pymt).
 These scripts can be run on a WMT executor
-in which the CDI
-and the [FrostNumberModel](https://github.com/permamodel/permamodel)
-have been installed as components.
+in which the CDI has been installed,
+as well as the [FrostNumberModel](https://github.com/permamodel/permamodel)
+and [Hydrotrend](https://github.com/kettner/hydrotrend),
+components.
 For example:
 
     $ python pymt-frostnumbermodel-vector-parameter-study.py

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # CSDMS Dakota interface examples
 
-This is a set of [Jupyter Notebooks](http://jupyter.org/)
-that demonstrate how the CSDMS Dakota interface
+A set of [Jupyter Notebooks](http://jupyter.org/)
+demonstrate how the CSDMS Dakota interface (CDI)
 can be used.
 
 From this directory,
@@ -10,3 +10,13 @@ start a Jupyter Notebook:
     $ jupyter notebook
 
 and select one of the Notebooks to run.
+
+The script **pymt-frostnumbermodel-vector-parameter-study.py**
+demonstrates how the CDI can be called as a component
+using [PyMT](https://github.com/csdms/pymt).
+This script can be run on a WMT executor
+in which the CDI
+and the [FrostNumberModel](https://github.com/permamodel/permamodel)
+have been installed as components:
+
+    $ python pymt-frostnumbermodel-vector-parameter-study.py

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,12 +11,17 @@ start a Jupyter Notebook:
 
 and select one of the Notebooks to run.
 
-The script **pymt-frostnumbermodel-vector-parameter-study.py**
-demonstrates how the CDI can be called as a component
+The scripts
+
+* **pymt-frostnumbermodel-vector-parameter-study.py** and
+* **pymt-frostnumbermodel-multidim-parameter-study.py**
+
+demonstrate how the CDI can be called as a component
 using [PyMT](https://github.com/csdms/pymt).
-This script can be run on a WMT executor
+These scripts can be run on a WMT executor
 in which the CDI
 and the [FrostNumberModel](https://github.com/permamodel/permamodel)
-have been installed as components:
+have been installed as components.
+For example:
 
     $ python pymt-frostnumbermodel-vector-parameter-study.py

--- a/examples/hydrotrend-centered-parameter-study.ipynb
+++ b/examples/hydrotrend-centered-parameter-study.ipynb
@@ -74,7 +74,7 @@
    },
    "outputs": [],
    "source": [
-    "d = Dakota(method='centered_parameter_study', component='hydrotrend')"
+    "d = Dakota(method='centered_parameter_study', plugin='hydrotrend')"
    ]
   },
   {
@@ -171,7 +171,7 @@
    "source": [
     "from dakotathon.plugins.base import write_dflt_file\n",
     "\n",
-    "default_input_file = write_dflt_file(template_file, parameters_file)\n",
+    "default_input_file = write_dflt_file(template_file, parameters_file, run_duration=365)\n",
     "print default_input_file"
    ]
   },
@@ -251,6 +251,37 @@
    "source": [
     "%cat dakota.dat"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I've included my output for comparison."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "%eval_id interface starting_mean_annual_temperature total_annual_precipitation      Qs_median         Q_mean \n",
+    "       1     CSDMS             15              2          4.907    101.3142499 \n",
+    "       2     CSDMS             10              2          2.435    101.2442425 \n",
+    "       3     CSDMS           12.5              2          3.524    101.3139131 \n",
+    "       4     CSDMS           17.5              2          6.608    101.3142499 \n",
+    "       5     CSDMS             20              2           8.67    101.3142499 \n",
+    "       6     CSDMS             15              1          3.783    49.13904014 \n",
+    "       7     CSDMS             15            1.2          4.061    59.54595737 \n",
+    "       8     CSDMS             15            1.4          4.263    69.96313812 \n",
+    "       9     CSDMS             15            1.6          4.518    80.40633878 \n",
+    "      10     CSDMS             15            1.8          4.567    90.85803505 \n",
+    "      11     CSDMS             15            2.2           5.13    111.7797497 \n",
+    "      12     CSDMS             15            2.4          5.324    122.2484547 \n",
+    "      13     CSDMS             15            2.6          5.474    132.7260839 \n",
+    "      14     CSDMS             15            2.8          5.626     143.206995 \n",
+    "      15     CSDMS             15              3          5.812       153.6976\n",
+    "```"
+   ]
   }
  ],
  "metadata": {
@@ -269,7 +300,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/hydrotrend-polynomial-chaos-study.ipynb
+++ b/examples/hydrotrend-polynomial-chaos-study.ipynb
@@ -71,7 +71,7 @@
    },
    "outputs": [],
    "source": [
-    "d = Dakota(method='polynomial_chaos', variables='normal_uncertain', component='hydrotrend')"
+    "d = Dakota(method='polynomial_chaos', variables='normal_uncertain', plugin='hydrotrend')"
    ]
   },
   {
@@ -201,7 +201,7 @@
    "source": [
     "from dakotathon.plugins.base import write_dflt_file\n",
     "\n",
-    "default_input_file = write_dflt_file(template_file, parameters_file, run_duration=10)\n",
+    "default_input_file = write_dflt_file(template_file, parameters_file, run_duration=10*365)\n",
     "print default_input_file"
    ]
   },
@@ -339,7 +339,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/hydrotrend-sampling-study.ipynb
+++ b/examples/hydrotrend-sampling-study.ipynb
@@ -75,7 +75,7 @@
    },
    "outputs": [],
    "source": [
-    "d = Dakota(method='sampling', variables='uniform_uncertain', component='hydrotrend')"
+    "d = Dakota(method='sampling', variables='uniform_uncertain', plugin='hydrotrend')"
    ]
   },
   {
@@ -197,7 +197,7 @@
    "source": [
     "from dakotathon.plugins.base import write_dflt_file\n",
     "\n",
-    "default_input_file = write_dflt_file(template_file, parameters_file, run_duration=10)\n",
+    "default_input_file = write_dflt_file(template_file, parameters_file, run_duration=10*365)\n",
     "print default_input_file"
    ]
   },
@@ -339,7 +339,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/hydrotrend-stochastic-collocation-study.ipynb
+++ b/examples/hydrotrend-stochastic-collocation-study.ipynb
@@ -71,7 +71,7 @@
    },
    "outputs": [],
    "source": [
-    "d = Dakota(method='stoch_collocation', variables='normal_uncertain', component='hydrotrend')"
+    "d = Dakota(method='stoch_collocation', variables='normal_uncertain', plugin='hydrotrend')"
    ]
   },
   {
@@ -201,7 +201,7 @@
    "source": [
     "from dakotathon.plugins.base import write_dflt_file\n",
     "\n",
-    "default_input_file = write_dflt_file(template_file, parameters_file, run_duration=10)\n",
+    "default_input_file = write_dflt_file(template_file, parameters_file, run_duration=10*365)\n",
     "print default_input_file"
    ]
   },
@@ -339,7 +339,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/pymt-frostnumbermodel-multidim-parameter-study.py
+++ b/examples/pymt-frostnumbermodel-multidim-parameter-study.py
@@ -26,16 +26,16 @@ parameters = {
 
 parameters, substitutes = configure_parameters(parameters)
 
-work_dir = c.setup(os.getcwd(), **substitutes)
+parameters['run_directory'] = c.setup(os.getcwd(), **substitutes)
 
 cfg_file = 'frostnumber_model.cfg'  # get from pymt eventually
+parameters['initialize_args'] = cfg_file
 dtmpl_file = cfg_file + '.dtmpl'
 os.rename(cfg_file, dtmpl_file)
-parameters['template_file'] = os.path.join(work_dir, dtmpl_file)
+parameters['template_file'] = dtmpl_file
 
-d.setup(work_dir, **parameters)
+d.setup(parameters['run_directory'], **parameters)
 
-d.initialize(os.path.join(work_dir, 'dakota.yaml'))
+d.initialize('dakota.yaml')
 d.update()
 d.finalize()
-

--- a/examples/pymt-frostnumbermodel-multidim-parameter-study.py
+++ b/examples/pymt-frostnumbermodel-multidim-parameter-study.py
@@ -1,0 +1,41 @@
+"""An example of using Dakota as a component with PyMT.
+
+This example requires a WMT executor with PyMT installed, as well as
+the CSDMS Dakota interface and FrostNumberModel installed as
+components.
+
+"""
+import os
+from pymt.components import MultidimParameterStudy, FrostNumberModel
+from dakotathon.utils import configure_parameters
+
+
+c, d = FrostNumberModel(), MultidimParameterStudy()
+
+parameters = {
+    'component': type(c).__name__,
+    'descriptors': ['T_air_min', 'T_air_max'],
+    'partitions': [3, 3],
+    'lower_bounds': [-20.0, 5.0],
+    'upper_bounds': [-5.0, 20.0],
+    'response_descriptors': ['frostnumber__air',
+                             'frostnumber__surface',
+                             'frostnumber__stefan'],
+    'response_statistics': ['median', 'median', 'median']
+    }
+
+parameters, substitutes = configure_parameters(parameters)
+
+work_dir = c.setup(os.getcwd(), **substitutes)
+
+cfg_file = 'frostnumber_model.cfg'  # get from pymt eventually
+dtmpl_file = cfg_file + '.dtmpl'
+os.rename(cfg_file, dtmpl_file)
+parameters['template_file'] = os.path.join(work_dir, dtmpl_file)
+
+d.setup(work_dir, **parameters)
+
+d.initialize(os.path.join(work_dir, 'dakota.yaml'))
+d.update()
+d.finalize()
+

--- a/examples/pymt-frostnumbermodel-vector-parameter-study.py
+++ b/examples/pymt-frostnumbermodel-vector-parameter-study.py
@@ -24,16 +24,16 @@ parameters = {
 
 parameters, substitutes = configure_parameters(parameters)
 
-work_dir = c.setup(os.getcwd(), **substitutes)
+parameters['run_directory'] = c.setup(os.getcwd(), **substitutes)
 
 cfg_file = 'frostnumber_model.cfg'  # get from pymt eventually
+parameters['initialize_args'] = cfg_file
 dtmpl_file = cfg_file + '.dtmpl'
 os.rename(cfg_file, dtmpl_file)
-parameters['template_file'] = os.path.join(work_dir, dtmpl_file)
+parameters['template_file'] = dtmpl_file
 
-d.setup(work_dir, **parameters)
+d.setup(parameters['run_directory'], **parameters)
 
-d.initialize(os.path.join(work_dir, 'dakota.yaml'))
+d.initialize('dakota.yaml')
 d.update()
 d.finalize()
-

--- a/examples/pymt-frostnumbermodel-vector-parameter-study.py
+++ b/examples/pymt-frostnumbermodel-vector-parameter-study.py
@@ -1,0 +1,39 @@
+"""An example of using Dakota as a component with PyMT.
+
+This example requires a WMT executor with PyMT installed, as well as
+the CSDMS Dakota interface and FrostNumberModel installed as
+components.
+
+"""
+import os
+from pymt.components import VectorParameterStudy, FrostNumberModel
+from dakotathon.utils import configure_parameters
+
+
+c, d = FrostNumberModel(), VectorParameterStudy()
+
+parameters = {
+    'component': type(c).__name__,
+    'descriptors': 'T_air_min',
+    'initial_point': -10.0,
+    'final_point': -5.0,
+    'n_steps': 5,
+    'response_descriptors': 'frostnumber__air',
+    'response_statistics': 'median',
+    }
+
+parameters, substitutes = configure_parameters(parameters)
+
+work_dir = c.setup(os.getcwd(), **substitutes)
+
+cfg_file = 'frostnumber_model.cfg'  # get from pymt eventually
+dtmpl_file = cfg_file + '.dtmpl'
+os.rename(cfg_file, dtmpl_file)
+parameters['template_file'] = os.path.join(work_dir, dtmpl_file)
+
+d.setup(work_dir, **parameters)
+
+d.initialize(os.path.join(work_dir, 'dakota.yaml'))
+d.update()
+d.finalize()
+

--- a/examples/pymt-hydrotrend-centered-parameter-study.py
+++ b/examples/pymt-hydrotrend-centered-parameter-study.py
@@ -14,6 +14,7 @@ c, d = Hydrotrend(), CenteredParameterStudy()
 
 parameters = {
     'component': type(c).__name__,
+    'run_duration': 365,               # days
     'auxiliary_files': 'HYDRO0.HYPS',  # the default Waipaoa hypsometry
     'descriptors': ['starting_mean_annual_temperature',
                     'total_annual_precipitation'],
@@ -24,17 +25,16 @@ parameters = {
                              'channel_exit_water__volume_flow_rate'],
     'response_statistics': ['median', 'mean']
     }
+dparameters, cparameters = configure_parameters(parameters)
 
-parameters, substitutes = configure_parameters(parameters)
-
-parameters['run_directory'] = c.setup(os.getcwd(), **substitutes)
+dparameters['run_directory'] = c.setup(os.getcwd(), **cparameters)
 
 cfg_file = 'HYDRO.IN'  # get from pymt eventually
 dtmpl_file = cfg_file + '.dtmpl'
 os.rename(cfg_file, dtmpl_file)
-parameters['template_file'] = dtmpl_file
+dparameters['template_file'] = dtmpl_file
 
-d.setup(parameters['run_directory'], **parameters)
+d.setup(dparameters['run_directory'], **dparameters)
 
 d.initialize('dakota.yaml')
 d.update()

--- a/examples/pymt-hydrotrend-centered-parameter-study.py
+++ b/examples/pymt-hydrotrend-centered-parameter-study.py
@@ -1,0 +1,42 @@
+"""An example of using Dakota as a component with PyMT.
+
+This example requires a WMT executor with PyMT installed, as well as
+the CSDMS Dakota interface and Hydrotrend installed as
+components.
+
+"""
+import os
+from pymt.components import CenteredParameterStudy, Hydrotrend
+from dakotathon.utils import configure_parameters
+
+
+c, d = Hydrotrend(), CenteredParameterStudy()
+
+parameters = {
+    'component': type(c).__name__,
+    'auxiliary_files': 'HYDRO0.HYPS',  # the default Waipaoa hypsometry
+    'descriptors': ['starting_mean_annual_temperature',
+                    'total_annual_precipitation'],
+    'initial_point': [15.0, 2.0],
+    'steps_per_variable': [2, 5],
+    'step_vector': [2.5, 0.2],
+    'response_descriptors': ['channel_exit_water_sediment~suspended__mass_flow_rate',
+                             'channel_exit_water__volume_flow_rate'],
+    'response_statistics': ['median', 'mean']
+    }
+
+parameters, substitutes = configure_parameters(parameters)
+
+parameters['run_directory'] = c.setup(os.getcwd(), **substitutes)
+
+cfg_file = 'HYDRO.IN'  # get from pymt eventually
+dtmpl_file = cfg_file + '.dtmpl'
+os.rename(cfg_file, dtmpl_file)
+parameters['template_file'] = dtmpl_file
+
+d.setup(parameters['run_directory'], **parameters)
+
+d.initialize('dakota.yaml')
+d.update()
+d.finalize()
+

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ use_setuptools()
 from setuptools import setup, find_packages
 from dakotathon import __version__
 from dakotathon.run_plugin import plugin_script
+from dakotathon.run_component import component_script
 
 
 setup(name='dakotathon',
@@ -21,7 +22,8 @@ setup(name='dakotathon',
       packages=find_packages(exclude=['*.tests']),
       entry_points={
           'console_scripts': [
-              plugin_script + ' = dakotathon.run_plugin:main'
+              plugin_script + ' = dakotathon.run_plugin:main',
+              component_script + ' = dakotathon.run_component:main'
           ]
       },
       keywords='CSDMS Dakota uncertainty sensitivity model modeling',


### PR DESCRIPTION
This pull request updates the CDI to work in a WMT executor with [PyMT](https://github.com/csdms/pymt) and any other component installed in the executor. It uses the existing Dakota BMI code, but adds a new script, `dakota_run_component`, to complement the existing `dakota_run_plugin`. The BMI metadata files were heavily edited to make everything work.

I've written a few examples (in the **examples** directory) that demonstrate using Dakota with PyMT + FrostNumberModel and Hydrotrend. Here's one of them, in script form:

```python
import os
from pymt.components import VectorParameterStudy, FrostNumberModel
from dakotathon.utils import configure_parameters


c, d = FrostNumberModel(), VectorParameterStudy()

parameters = {
    'component': type(c).__name__,
    'descriptors': 'T_air_min',
    'initial_point': -10.0,
    'final_point': -5.0,
    'n_steps': 5,
    'response_descriptors': 'frostnumber__air',
    'response_statistics': 'median',
    }

parameters, substitutes = configure_parameters(parameters)

parameters['run_directory'] = c.setup(os.getcwd(), **substitutes)

cfg_file = 'frostnumber_model.cfg'  # get from pymt eventually
parameters['initialize_args'] = cfg_file
dtmpl_file = cfg_file + '.dtmpl'
os.rename(cfg_file, dtmpl_file)
parameters['template_file'] = dtmpl_file

d.setup(parameters['run_directory'], **parameters)

d.initialize('dakota.yaml')
d.update()
d.finalize()
```

You still have to know some things about Dakota to use the CDI in PyMT, but I think it's a lot easier to use than Dakota alone.