### PR TITLE
Debug install failure

### DIFF
--- a/.ci/travis/install_python.sh
+++ b/.ci/travis/install_python.sh
@@ -17,6 +17,4 @@ conda config --set always_yes yes --set changeps1 no
 conda info -a
 conda install python=$TRAVIS_PYTHON_VERSION
 conda install -q -c conda-forge conda-build
-conda install -q anaconda-client
-conda install -q coverage
-conda install -q sphinx
+conda install -q -c conda-forge anaconda-client coverage sphinx

--- a/.ci/travis/install_python.sh
+++ b/.ci/travis/install_python.sh
@@ -16,7 +16,7 @@ hash -r
 conda config --set always_yes yes --set changeps1 no
 conda info -a
 conda install python=$TRAVIS_PYTHON_VERSION
-conda install -q conda-build
+conda install -q -c conda-forge conda-build
 conda install -q anaconda-client
 conda install -q coverage
 conda install -q sphinx

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - pip install coveralls
   - source .ci/travis/install_dakota.sh
   - dakota --version
-  - conda install -q -c csdms hydrotrend
+  - conda install -q -c csdms -c conda-forge hydrotrend
 
 install:
   - conda install -q -c csdms dakotathon --use-local


### PR DESCRIPTION
Installing the locally built `dakotathon` package on Travis was failing with a cryptic message:

```
$ conda install -q -c csdms dakotathon --use-local
Fetching package metadata ...........
Solving package specifications: 

PackageNotFoundError: Package not found: Conda could not find '
```

See, e.g., https://travis-ci.org/csdms/dakota/jobs/211894313.

It seems (???) that using the `conda`, `conda-env`, and `conda-build` packages in the default channel are the cause of the problem. When I use the versions of these packages supplied by conda-forge, `dakotathon` installs without errors.

I'd prefer to use the packages in the default channel over those supplied by conda-forge. I'll open an issue to revisit (in the near future) the changes I've made in this PR and hopefully revert them.