### PR TITLE
Multiple issues: dynamic file and path naming, deleting blocks, fixing run() crashes

### DIFF
--- a/dakotathon/dakota.py
+++ b/dakotathon/dakota.py
@@ -36,11 +36,11 @@ class Dakota(Experiment):
             is placed (default is the current directory).
         configuration_file : str, optional
             A Dakota instance serialized to a YAML file (default is
-            **dakota.yaml**). 
+            **dakota.yaml**).
         input_file : str, optional
             Name of Dakota input file (default is **dakota.in**).
         output_file : str, optional
-            Name of Dakota output file (default is **dakota.out**). 
+            Name of Dakota output file (default is **dakota.out**).
         run_log : str, optional
             Name of Dakota log file (default is **run.log***)
         error_log : str, optional
@@ -76,7 +76,7 @@ class Dakota(Experiment):
         self._auxiliary_files = auxiliary_files
         self.run_log = run_log
         self.error_log = error_log
-        
+
     @property
     def run_directory(self):
         """The run directory path."""
@@ -205,12 +205,12 @@ class Dakota(Experiment):
             self.configuration_file = config_file
 
         props = get_attributes(self)
-        
+
         removed_blocks = set(Experiment.blocks)-set(self.blocks)
         for removed_block in removed_blocks:
             temp = props.pop(removed_block)
             del temp
-        
+
         for section in self.blocks:
             section_props = get_attributes(props.pop(section))
             props = dict(list(props.items()) + list(section_props.items()))
@@ -239,7 +239,7 @@ class Dakota(Experiment):
         """
         if input_file is not None:
             self.input_file = input_file
-        
+
         input_file_path = os.path.abspath(os.path.join(self.run_directory,
                                                         self.input_file))
         with open(input_file_path, 'w') as fp:
@@ -262,9 +262,9 @@ class Dakota(Experiment):
 
     def run(self):
         """Run the Dakota experiment.
-        
+
         Run is executed in the directory specified by run_directory keyword and
-        run log and error log are created. 
+        run log and error log are created.
         """
         os.chdir(self.run_directory)
 
@@ -275,6 +275,3 @@ class Dakota(Experiment):
                                  '-o', self.output_file],
                                 stdout=file_out,
                                 stderr=error_out)
-    
-
-

--- a/dakotathon/dakota.py
+++ b/dakotathon/dakota.py
@@ -17,6 +17,7 @@ class Dakota(Experiment):
                  configuration_file='dakota.yaml',
                  input_file='dakota.in',
                  output_file='dakota.out',
+                 run_log='run.log',
                  template_file=None,
                  auxiliary_files=(),
                  **kwargs):
@@ -68,7 +69,7 @@ class Dakota(Experiment):
         self.output_file = output_file
         self._template_file = template_file
         self._auxiliary_files = auxiliary_files
-
+        self.run_log = run_log
     @property
     def run_directory(self):
         """The run directory path."""
@@ -256,8 +257,11 @@ class Dakota(Experiment):
         """Run the Dakota experiment."""
         os.chdir(self.run_directory)
 
-        subprocess.check_output(['dakota',
-                                 '-i', self.input_file,
-                                 '-o', self.output_file],
-                                stderr=subprocess.STDOUT) 
+        with open(self.run_log, "w") as file_out:
+            subprocess.call(['dakota',
+                             '-i', self.input_file,
+                             '-o', self.output_file],
+                            stdout=file_out)
+
+
 

--- a/dakotathon/dakota.py
+++ b/dakotathon/dakota.py
@@ -71,6 +71,7 @@ class Dakota(Experiment):
                             configuration_file=configuration_file,
                             **kwargs)
         configuration_file = os.path.abspath(os.path.join(run_directory, configuration_file))
+        
         self._run_directory = run_directory
         self._configuration_file = configuration_file
         self.input_file = input_file
@@ -244,7 +245,10 @@ class Dakota(Experiment):
             self.input_file = input_file
 
         input_file_path = os.path.abspath(os.path.join(self.run_directory,
-                                                        self.input_file))
+                                                       self.input_file))
+        if os.path.exists(os.path.abspath(self.run_directory)) == False:
+            os.mkdir(os.path.abspath(self.run_directory))
+        
         with open(input_file_path, 'w') as fp:
             fp.write(str(self))
 

--- a/dakotathon/dakota.py
+++ b/dakotathon/dakota.py
@@ -18,6 +18,7 @@ class Dakota(Experiment):
                  input_file='dakota.in',
                  output_file='dakota.out',
                  run_log='run.log',
+                 error_log='stderr.log',
                  template_file=None,
                  auxiliary_files=(),
                  **kwargs):
@@ -35,11 +36,15 @@ class Dakota(Experiment):
             is placed (default is the current directory).
         configuration_file : str, optional
             A Dakota instance serialized to a YAML file (default is
-            **dakota.yaml**).
+            **dakota.yaml**). 
         input_file : str, optional
-            Name of Dakota input file (default is **dakota.in**)
+            Name of Dakota input file (default is **dakota.in**).
         output_file : str, optional
-            Name of Dakota output file (default is **dakota.out**)
+            Name of Dakota output file (default is **dakota.out**). 
+        run_log : str, optional
+            Name of Dakota log file (default is **run.log***)
+        error_log : str, optional
+            Name of Dakota error log file (default is **stderr.log***)
         template_file : str, optional
             The Dakota template file, formed from the input file of
             the model to study, but with study variables replaced by
@@ -70,6 +75,8 @@ class Dakota(Experiment):
         self._template_file = template_file
         self._auxiliary_files = auxiliary_files
         self.run_log = run_log
+        self.error_log = error_log
+        
     @property
     def run_directory(self):
         """The run directory path."""
@@ -254,14 +261,20 @@ class Dakota(Experiment):
         self.write_input_file()
 
     def run(self):
-        """Run the Dakota experiment."""
+        """Run the Dakota experiment.
+        
+        Run is executed in the directory specified by run_directory keyword and
+        run log and error log are created. 
+        """
         os.chdir(self.run_directory)
 
         with open(self.run_log, "w") as file_out:
-            subprocess.call(['dakota',
-                             '-i', self.input_file,
-                             '-o', self.output_file],
-                            stdout=file_out)
-
+            with open(self.error_log, "w") as error_out:
+                subprocess.call(['dakota',
+                                 '-i', self.input_file,
+                                 '-o', self.output_file],
+                                stdout=file_out,
+                                stderr=error_out)
+    
 
 

--- a/dakotathon/dakota.py
+++ b/dakotathon/dakota.py
@@ -198,7 +198,7 @@ class Dakota(Experiment):
         props = get_attributes(self)
         for section in Experiment.blocks:
             section_props = get_attributes(props.pop(section))
-            props = dict(props.items() + section_props.items())
+            props = dict(list(props.items()) + list(section_props.items()))
 
         with open(self.configuration_file, 'w') as fp:
             yaml.safe_dump(props, fp, default_flow_style=False)

--- a/dakotathon/dakota.py
+++ b/dakotathon/dakota.py
@@ -14,7 +14,7 @@ class Dakota(Experiment):
 
     def __init__(self,
                  run_directory=os.getcwd(),
-                 configuration_file=os.path.abspath('dakota.yaml'),
+                 configuration_file='dakota.yaml',
                  input_file='dakota.in',
                  output_file='dakota.out',
                  template_file=None,
@@ -61,10 +61,11 @@ class Dakota(Experiment):
 
         """
         Experiment.__init__(self, **kwargs)
+        configuration_file = os.path.abspath(os.path.join(run_directory, configuration_file))
         self._run_directory = run_directory
         self._configuration_file = configuration_file
-        self.input_file = input_file
-        self.output_file = output_file
+        self.input_file = os.path.abspath(os.path.join(run_directory, input_file))
+        self.output_file = os.path.abspath(os.path.join(run_directory, output_file))
         self._template_file = template_file
         self._auxiliary_files = auxiliary_files
 
@@ -244,6 +245,9 @@ class Dakota(Experiment):
 
     def run(self):
         """Run the Dakota experiment."""
+        subprocess.call(['dakota', '-i', self.input_file , '-o', self.output_file, '&>', 'run.log'])
+
+        
         subprocess.check_output(['dakota',
                                  '-i', self.input_file,
                                  '-o', self.output_file],

--- a/dakotathon/dakota.py
+++ b/dakotathon/dakota.py
@@ -197,7 +197,13 @@ class Dakota(Experiment):
             self.configuration_file = config_file
 
         props = get_attributes(self)
-        for section in Experiment.blocks:
+        
+        removed_blocks = set(Experiment.blocks)-set(self.blocks)
+        for removed_block in removed_blocks:
+            temp = props.pop(removed_block)
+            del temp
+        
+        for section in self.blocks:
             section_props = get_attributes(props.pop(section))
             props = dict(list(props.items()) + list(section_props.items()))
 
@@ -248,7 +254,6 @@ class Dakota(Experiment):
 
     def run(self):
         """Run the Dakota experiment."""
-        subprocess.call(['dakota', '-i', self.input_file , '-o', self.output_file, '&>', 'run.log'])
         os.chdir(self.run_directory)
 
         subprocess.check_output(['dakota',

--- a/dakotathon/dakota.py
+++ b/dakotathon/dakota.py
@@ -246,6 +246,7 @@ class Dakota(Experiment):
 
         input_file_path = os.path.abspath(os.path.join(self.run_directory,
                                                        self.input_file))
+        
         if os.path.exists(os.path.abspath(self.run_directory)) == False:
             os.mkdir(os.path.abspath(self.run_directory))
         

--- a/dakotathon/dakota.py
+++ b/dakotathon/dakota.py
@@ -64,8 +64,8 @@ class Dakota(Experiment):
         configuration_file = os.path.abspath(os.path.join(run_directory, configuration_file))
         self._run_directory = run_directory
         self._configuration_file = configuration_file
-        self.input_file = os.path.abspath(os.path.join(run_directory, input_file))
-        self.output_file = os.path.abspath(os.path.join(run_directory, output_file))
+        self.input_file = input_file
+        self.output_file = output_file
         self._template_file = template_file
         self._auxiliary_files = auxiliary_files
 
@@ -225,7 +225,10 @@ class Dakota(Experiment):
         """
         if input_file is not None:
             self.input_file = input_file
-        with open(self.input_file, 'w') as fp:
+        
+        input_file_path = os.path.abspath(os.path.join(self.run_directory,
+                                                        self.input_file))
+        with open(input_file_path, 'w') as fp:
             fp.write(str(self))
 
     def setup(self):
@@ -246,9 +249,10 @@ class Dakota(Experiment):
     def run(self):
         """Run the Dakota experiment."""
         subprocess.call(['dakota', '-i', self.input_file , '-o', self.output_file, '&>', 'run.log'])
+        os.chdir(self.run_directory)
 
-        
         subprocess.check_output(['dakota',
                                  '-i', self.input_file,
                                  '-o', self.output_file],
-                                stderr=subprocess.STDOUT)
+                                stderr=subprocess.STDOUT) 
+

--- a/dakotathon/dakota.py
+++ b/dakotathon/dakota.py
@@ -66,7 +66,10 @@ class Dakota(Experiment):
         >>> d = Dakota(method='vector_parameter_study')
 
         """
-        Experiment.__init__(self, **kwargs)
+        Experiment.__init__(self,
+                            run_directory=run_directory,
+                            configuration_file=configuration_file,
+                            **kwargs)
         configuration_file = os.path.abspath(os.path.join(run_directory, configuration_file))
         self._run_directory = run_directory
         self._configuration_file = configuration_file

--- a/dakotathon/experiment.py
+++ b/dakotathon/experiment.py
@@ -95,6 +95,7 @@ class Experiment(object):
                 kwargs['upper_bounds']
             except KeyError:
                 kwargs['upper_bounds'] = (2.0, 2.0)
+  
         for section in Experiment.blocks:
             cls = self._import(section, eval(section), **kwargs)
             attr = '_' + section

--- a/dakotathon/experiment.py
+++ b/dakotathon/experiment.py
@@ -251,6 +251,6 @@ class Experiment(object):
         <BLANKLINE>
         """
         s = '# Dakota input file\n'
-        for section in Experiment.blocks:
+        for section in self.blocks:
             s += str(getattr(self, section))
         return s

--- a/dakotathon/interface/base.py
+++ b/dakotathon/interface/base.py
@@ -1,7 +1,7 @@
 """An abstract base class for all Dakota interfaces."""
 
 from abc import ABCMeta, abstractmethod
-
+import os
 
 class InterfaceBase(object):
 
@@ -16,7 +16,8 @@ class InterfaceBase(object):
                  analysis_driver='rosenbrock',
                  asynchronous=False,
                  evaluation_concurrency=2,
-                 work_directory='run',
+                 work_directory=os.getcwd(),
+                 work_folder='run',
                  parameters_file='params.in',
                  results_file='results.out',
                  **kwargs):
@@ -37,8 +38,11 @@ class InterfaceBase(object):
         evaluation_concurrency : int, optional
             Number of concurrent evaluations (default is 2).
         work_directory : str, optional
-            The file path to the work directory (default is a new directory
-            called **run** within the run directory).
+            The file path to the work directory (default is the run 
+            directory)
+        work_folder : str, optional
+            The name of the folders Dakota will create for each run 
+            (default is **run**).
         parameters_file : str, optional
             The name of the parameters file (default is **params.in**).
         results_file : str, optional
@@ -54,7 +58,7 @@ class InterfaceBase(object):
         self._evaluation_concurrency = evaluation_concurrency
         self.parameters_file = parameters_file
         self.results_file = results_file
-        self.work_directory = work_directory
+        self.work_directory = os.path.join(work_directory, work_folder)
 
     @property
     def asynchronous(self):

--- a/dakotathon/interface/base.py
+++ b/dakotathon/interface/base.py
@@ -20,7 +20,7 @@ class InterfaceBase(object):
                  parameters_file='params.in',
                  results_file='results.out',
                  **kwargs):
-        
+
         """Create a default interface.
 
         Parameters
@@ -37,8 +37,8 @@ class InterfaceBase(object):
         evaluation_concurrency : int, optional
             Number of concurrent evaluations (default is 2).
         work_directory : str, optional
-            The file path to the work directory (default is a new directory 
-            called **run** within the run directory). 
+            The file path to the work directory (default is a new directory
+            called **run** within the run directory).
         parameters_file : str, optional
             The name of the parameters file (default is **params.in**).
         results_file : str, optional

--- a/dakotathon/interface/base.py
+++ b/dakotathon/interface/base.py
@@ -16,7 +16,11 @@ class InterfaceBase(object):
                  analysis_driver='rosenbrock',
                  asynchronous=False,
                  evaluation_concurrency=2,
+                 work_directory='run',
+                 parameters_file='params.in',
+                 results_file='results.out',
                  **kwargs):
+        
         """Create a default interface.
 
         Parameters
@@ -32,6 +36,13 @@ class InterfaceBase(object):
             Set to perform asynchronous evaluations (default is False).
         evaluation_concurrency : int, optional
             Number of concurrent evaluations (default is 2).
+        work_directory : str, optional
+            The file path to the work directory (default is a new directory 
+            called **run** within the run directory). 
+        parameters_file : str, optional
+            The name of the parameters file (default is **params.in**).
+        results_file : str, optional
+            The name of the results file (default is **results.out**).
         **kwargs
             Optional keyword arguments.
 
@@ -41,6 +52,9 @@ class InterfaceBase(object):
         self.analysis_driver = analysis_driver
         self._asynchronous = asynchronous
         self._evaluation_concurrency = evaluation_concurrency
+        self.parameters_file = parameters_file
+        self.results_file = results_file
+        self.work_directory = work_directory
 
     @property
     def asynchronous(self):

--- a/dakotathon/interface/fork.py
+++ b/dakotathon/interface/fork.py
@@ -28,8 +28,10 @@ class Fork(InterfaceBase):
         """
         InterfaceBase.__init__(self, **kwargs)
         self.interface = self.__module__.rsplit('.')[-1]
-        self._configuration_file = os.path.abspath(os.path.join(kwargs.pop('run_directory'), kwargs.pop('configuration_file')))
-
+        try:
+            self._configuration_file = os.path.abspath(os.path.join(kwargs.pop('run_directory'), kwargs.pop('configuration_file')))
+        except KeyError:
+            self._configuration_file = os.path.abspath('dakota.yaml')
 
     def __str__(self):
         """Define the block for a fork interface.

--- a/dakotathon/interface/fork.py
+++ b/dakotathon/interface/fork.py
@@ -11,7 +11,11 @@ class Fork(InterfaceBase):
 
     """Define attributes for a Dakota fork interface."""
 
-    def __init__(self, **kwargs):
+    def __init__(self,
+                 work_directory='run',
+                 parameters_file='params.in',
+                 results_file='results.out',
+                 **kwargs):
         """Create a fork interface.
 
         Parameters
@@ -29,8 +33,9 @@ class Fork(InterfaceBase):
         InterfaceBase.__init__(self, **kwargs)
         self.interface = self.__module__.rsplit('.')[-1]
         self._configuration_file = os.path.abspath('dakota.yaml')
-        self.parameters_file = 'params.in'
-        self.results_file = 'results.out'
+        self.parameters_file = parameters_file
+        self.results_file = results_file
+        self.work_directory = work_directory
 
     def __str__(self):
         """Define the block for a fork interface.
@@ -46,7 +51,7 @@ class Fork(InterfaceBase):
         s += '  parameters_file = {!r}\n'.format(self.parameters_file) \
              + '  results_file = {!r}\n'.format(self.results_file) \
              + '  work_directory\n' \
-             + '    named \'run\'\n' \
+             + '    named {!r}\n'.format(self.work_directory) \
              + '    directory_tag\n' \
              + '    directory_save\n' \
              + '  file_save\n'

--- a/dakotathon/interface/fork.py
+++ b/dakotathon/interface/fork.py
@@ -28,7 +28,7 @@ class Fork(InterfaceBase):
         """
         InterfaceBase.__init__(self, **kwargs)
         self.interface = self.__module__.rsplit('.')[-1]
-        self._configuration_file = os.path.abspath(os.path.join(self.run_directory, self.configuration_file))
+        self._configuration_file = os.path.abspath(os.path.join(kwargs.pop('run_directory'), kwargs.pop('configuration_file')))
 
 
     def __str__(self):

--- a/dakotathon/interface/fork.py
+++ b/dakotathon/interface/fork.py
@@ -11,11 +11,7 @@ class Fork(InterfaceBase):
 
     """Define attributes for a Dakota fork interface."""
 
-    def __init__(self,
-                 work_directory='run',
-                 parameters_file='params.in',
-                 results_file='results.out',
-                 **kwargs):
+    def __init__(self, **kwargs):
         """Create a fork interface.
 
         Parameters
@@ -32,10 +28,8 @@ class Fork(InterfaceBase):
         """
         InterfaceBase.__init__(self, **kwargs)
         self.interface = self.__module__.rsplit('.')[-1]
-        self._configuration_file = os.path.abspath('dakota.yaml')
-        self.parameters_file = parameters_file
-        self.results_file = results_file
-        self.work_directory = work_directory
+        self._configuration_file = os.path.abspath(os.path.join(self.run_directory, self.configuration_file))
+
 
     def __str__(self):
         """Define the block for a fork interface.

--- a/dakotathon/tests/test_dakota.py
+++ b/dakotathon/tests/test_dakota.py
@@ -198,3 +198,27 @@ def test_default_run_without_input_file():
             k.run()
         except CalledProcessError:
             pass
+
+def test_changing_parameter_names():
+    """Test ability to provide parameter names."""
+    run_directory = 'looped_runs'
+    configuration_file = 'an_excellent_yaml.yaml'
+    run_log = 'run_output_here.log'
+    error_log = 'lots_of_errors.log'
+    k = Dakota(method='vector_parameter_study',
+               run_directory=run_directory,
+               configuration_file=configuration_file,
+               run_log=run_log,
+               error_log=error_log)
+    k.write_input_file()
+    k.serialize()
+    k.run()
+
+    os.remove(configuration_file)
+    os.remove(run_log)
+    os.remove(error_log)
+    teardown_module()
+    os.chdir('..')
+    os.rmdir(run_directory)
+
+        

--- a/dakotathon/tests/test_dakota.py
+++ b/dakotathon/tests/test_dakota.py
@@ -204,7 +204,7 @@ def test_changing_parameter_names():
     run_directory = 'looped_runs'
     configuration_file = 'an_excellent_yaml.yaml'
     run_log = 'run_output_here.log'
-    error_log = 'lots_of_errors.log'
+    error_log = 'no_errors_here.log'
     k = Dakota(method='vector_parameter_study',
                run_directory=run_directory,
                configuration_file=configuration_file,
@@ -221,4 +221,61 @@ def test_changing_parameter_names():
     os.chdir('..')
     os.rmdir(run_directory)
 
-        
+def test_running_in_different_directory():
+    """Test ability to provide parameter names."""
+    work_folder = 'dakota_runs'
+    run_directory = os.path.abspath(os.path.join(os.getcwd(), 'running_here'))
+    work_directory = os.path.abspath(os.path.join(run_directory, '..','working_here'))
+    configuration_file = 'another_excellent_yaml.yaml'
+    run_log = 'run_output_should_be_here.log'
+    error_log = 'no_errors_inside.log'
+    parameters_file = 'parameters_here.in'
+    results_file = 'neato_results_here.out'
+    input_file = 'dakota_LHC.in'
+    output_file = 'dakota_LHC.out'
+    
+    k = Dakota(method='sampling',
+               variables='uniform_uncertain',
+               input_file=input_file,
+               output_file=output_file,
+               interface='fork',
+               run_directory=run_directory,
+               work_directory=work_directory,
+               work_folder=work_folder,
+               configuration_file=configuration_file,
+               run_log=run_log,
+               error_log=error_log,
+               parameters_file=parameters_file,
+               results_file=results_file)
+    k.write_input_file()
+    k.serialize()
+    k.run()
+    
+    # teardown. First the run directory.
+    lhc_filelist = [ f for f in os.listdir(".") if f.startswith("LHS") ]
+    for f in lhc_filelist:
+        os.remove(f)
+    os.remove(configuration_file)
+    os.remove(run_log)
+    os.remove(error_log)
+    os.remove(input_file)
+    os.remove(output_file)
+    teardown_module()
+    os.chdir('..')
+    os.rmdir(run_directory)
+
+    # Second the working directory.
+
+    num_runs = k.method.samples
+    os.chdir(work_directory)
+    for i in range(num_runs):
+        folder_name = '.'.join([work_folder, str(i+1)])
+        os.chdir(folder_name)
+        os.remove(parameters_file)
+        os.remove(results_file)
+        os.chdir('..')
+        os.rmdir(folder_name)
+    os.chdir('..')
+    os.rmdir(work_directory)
+
+

--- a/dakotathon/tests/test_dakota.py
+++ b/dakotathon/tests/test_dakota.py
@@ -261,6 +261,7 @@ def test_running_in_different_directory():
     os.remove(input_file)
     os.remove(output_file)
     teardown_module()
+    [os.remove(f) for f in os.listdir(".")]
     os.chdir('..')
     os.rmdir(run_directory)
 

--- a/dakotathon/tests/test_interface_base.py
+++ b/dakotathon/tests/test_interface_base.py
@@ -16,6 +16,13 @@ class Concrete(InterfaceBase):
     def __init__(self):
         InterfaceBase.__init__(self)
 
+class ConcreteKwargs(InterfaceBase):
+    
+    """A subclass of InterfaceBase with kwargs for testing."""
+    
+    def __init__(self, **kwargs):
+        InterfaceBase.__init__(self, **kwargs)
+
 
 def setup_module():
     """Fixture called before any tests are performed."""
@@ -108,3 +115,9 @@ def test_str_length_removing_asynchronous():
     s = str(b)
     n_lines = len(s.splitlines())
     assert_equal(n_lines, default_str_lines)
+
+def test_change_parameter_names():
+    """Test changing the parameter names."""
+    c = ConcreteKwargs(work_directory='yay',
+                       parameters_file='hello.in',
+                       results_file='goodbye.out')

--- a/dakotathon/tests/test_plugin_hydrotrend_run.py
+++ b/dakotathon/tests/test_plugin_hydrotrend_run.py
@@ -45,6 +45,10 @@ def teardown():
         os.remove(config_file)
     if os.path.exists('dakota.in'):
         os.remove('dakota.in')
+    if os.path.exists('run.log'):
+        os.remove('run.log')
+    if os.path.exists('stderr.log'):
+        os.remove('stderr.log')
     if is_hydrotrend_installed():
         for dname in glob.glob('HYDRO_*'):
             shutil.rmtree(dname)

--- a/dakotathon/utils.py
+++ b/dakotathon/utils.py
@@ -213,7 +213,7 @@ def to_iterable(x):
     Courtesy http://stackoverflow.com/a/6711233/1563298
 
     """
-    if isinstance(x, collections.Iterable) and not isinstance(x, basestring):
+    if isinstance(x, collections.Iterable) and not isinstance(x, str):
         return x
     else:
         return (x,)
@@ -256,7 +256,7 @@ def configure_parameters(params):
                 'auxiliary_files',]
     for item in to_check:
         try:
-            if isinstance(params[item], basestring):
+            if isinstance(params[item], str):
                 params[item] = [params[item]]
         except KeyError:
             pass

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -70,10 +70,10 @@ def _validate_md5(egg_name, data):
     if egg_name in md5_data:
         digest = md5(data).hexdigest()
         if digest != md5_data[egg_name]:
-            print >>sys.stderr, (
-                "md5 validation of %s failed!  (Possible download problem?)"
-                % egg_name
-            )
+            print("md5 validation of %s failed!"
+                  "(Possible download problem?)"
+                  % egg_name,
+                  file=sys.stderr)
             sys.exit(2)
     return data
 
@@ -100,17 +100,17 @@ def use_setuptools(
     try:
         import pkg_resources
     except ImportError:
-        return do_download()       
+        return do_download()
     try:
         pkg_resources.require("setuptools>="+version); return
-    except pkg_resources.VersionConflict, e:
+    except pkg_resources.VersionConflict as e:
         if was_imported:
-            print >>sys.stderr, (
-            "The required version of setuptools (>=%s) is not available, and\n"
-            "can't be installed while this script is running. Please install\n"
-            " a more recent version first, using 'easy_install -U setuptools'."
-            "\n\n(Currently using %r)"
-            ) % (version, e.args[0])
+            print("The required version of setuptools (>=%s) is not available, and\n"
+                  "can't be installed while this script is running. Please install\n"
+                  "a more recent version first, using 'easy_install -U setuptools'."
+                  "\n\n(Currently using %r)"
+                  % (version, e.args[0]),
+                  file=sys.stderr)
             sys.exit(2)
     except pkg_resources.DistributionNotFound:
         pass
@@ -216,10 +216,9 @@ def main(argv, version=DEFAULT_VERSION):
                 os.unlink(egg)
     else:
         if setuptools.__version__ == '0.0.1':
-            print >>sys.stderr, (
-            "You have an obsolete version of setuptools installed.  Please\n"
-            "remove it from your system entirely before rerunning this script."
-            )
+            print("You have an obsolete version of setuptools installed.  Please\n"
+                  "remove it from your system entirely before rerunning this script.",
+                  file=sys.stderr)
             sys.exit(2)
 
     req = "setuptools>="+version
@@ -238,8 +237,8 @@ def main(argv, version=DEFAULT_VERSION):
             from setuptools.command.easy_install import main
             main(argv)
         else:
-            print "Setuptools version",version,"or greater has been installed."
-            print '(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)'
+            print("Setuptools version",version,"or greater has been installed.")
+            print('(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)')
 
 def update_md5(filenames):
     """Update our built-in md5 registry"""
@@ -262,7 +261,7 @@ def update_md5(filenames):
 
     match = re.search("\nmd5_data = {\n([^}]+)}", src)
     if not match:
-        print >>sys.stderr, "Internal error!"
+        print("Internal error!", file=sys.stderr)
         sys.exit(2)
 
     src = src[:match.start(1)] + repl + src[match.end(1):]
@@ -276,9 +275,3 @@ if __name__=='__main__':
         update_md5(sys.argv[2:])
     else:
         main(sys.argv[1:])
-
-
-
-
-
-


### PR DESCRIPTION
This pull request addresses issues from #52 #55 and #56.

1. It permits the dynamic naming of file paths  run and work directories, dynamic naming of the configuration file, the parameter file, and the results file. 

2. It changes the run() method to use subprocess.call instead of subprocess.checkoutput and to include (dynamically named) standard output and standard error logs. 

3. It changes the methods for creating the dakota.yaml and dakota.in file to loop through only the blocks given in self.blocks rather than Experiment.blocks. Through this crude fix, setting
```dakota.blocks = ('method', 'variables', 'interface', 'responses')```
has the functional equivalent of removing the environment block. 

4. It has a few small fixes related to python 2-3 compatibility. It is branched off of kbarnhar/install_changes because in order to run dakota I needed my install changes. 