### PR TITLE
Update build dependencies on Linux

### DIFF
--- a/.ci/travis/install_dakota.sh
+++ b/.ci/travis/install_dakota.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
+# Install Dakota and its dependencies.
+
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    base_url="http://csdms.colorado.edu/pub/tools/dakota"
+    dakota_filename="dakota-6.4.0.Linux-Ubuntu.x86_64.tar.gz"
+    deb_filename="libicu48_4.8.1.1-12+deb7u3_amd64.deb"
+    wget $base_url/$deb_filename
+    sudo apt-get install libblas-dev liblapack3
+    sudo dpkg --install $deb_filename
+fi
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     base_url="https://dakota.sandia.gov/sites/default/files/distributions/public"
-    filename="dakota-6.4-public-Darwin.i386.tar.gz"
-else
-    base_url="http://csdms.colorado.edu/pub/tools/dakota"
-    filename="dakota-6.4.0.Linux-Ubuntu.x86_64.tar.gz"
+    dakota_filename="dakota-6.4-public-Darwin.i386.tar.gz"
 fi
 
-wget $base_url/$filename -O dakota.tar.gz
+wget $base_url/$dakota_filename -O dakota.tar.gz
 
-dakota_dir=$HOME/dakota
+dakota_dir=$HOME/dakota-sandia
 mkdir $dakota_dir && tar zxf dakota.tar.gz -C $dakota_dir --strip-components 1
-
-if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    sudo apt-get install libblas-dev liblapack-dev g++ gfortran fort77 libtrilinos-dev
-fi
 
 export PATH="$dakota_dir/bin:$dakota_dir/test:$PATH"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - pip install coveralls
   - source .ci/travis/install_dakota.sh
   - dakota --version
-  - conda install -q -c csdms -c conda-forge hydrotrend
+  - conda install -q -c csdms hydrotrend
 
 install:
   - conda install -q -c csdms dakotathon --use-local


### PR DESCRIPTION
Travis CI has upgraded from Ubuntu 12.04 LTS (precise) to 14.04 LTS (trusty), and some dependencies have changed. Note that the macOS build is not affected.

Note that we're still using the Dakota binary built against 12.04. It might be worthwhile to create a new binary built against 14.04.