### PR TITLE
Fix broken macOS py36 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - if [[ "$TRAVIS_TAG" == v* ]]; then export BUILD_STR=""; else export BUILD_STR="dev"; fi
   - source .ci/travis/install_python.sh
   - pip install -r requirements.txt
+  - conda install -c csdms-stack basic-modeling-interface
   - conda info -a
   - conda build -q -c csdms-stack .conda --old-build-string
   - pip install coveralls


### PR DESCRIPTION
I'm now installing `basic-modeling-interface` through `conda` instead of `pip`. See https://github.com/csdms/dakota/commit/75136dc507fa0cdc61563910cf3db2ed738c66f5#commitcomment-25032826 for more information.