### PR TITLE
Use HTTPS to access files on CSDMS website

### DIFF
--- a/.ci/travis/install_dakota.sh
+++ b/.ci/travis/install_dakota.sh
@@ -2,7 +2,7 @@
 # Install Dakota and its dependencies.
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    base_url="http://csdms.colorado.edu/pub/tools/dakota"
+    base_url="https://csdms.colorado.edu/pub/tools/dakota"
     dakota_filename="dakota-6.4.0.Linux-Ubuntu.x86_64.tar.gz"
     deb_filename="libicu48_4.8.1.1-12+deb7u3_amd64.deb"
     wget $base_url/$deb_filename


### PR DESCRIPTION
Recently OIT updated the CSDMS web server to use HTTPS site-wide. I was using an HTTP URL to download a Dakota build for Ubuntu from our website. This started failing after the update. I've fixed it here.