### PR TITLE
Use dakota binaries from Anaconda Cloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - conda info -a
   - conda build -q -c csdms-stack .conda --old-build-string
   - pip install coveralls
-  - source .ci/travis/install_dakota.sh
+  - conda install -c defaults -c csdms-stack -c conda-forge dakota
   - dakota --version
   - conda install -q -c csdms-stack hydrotrend
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ before_install:
   - echo "Build on $TRAVIS_OS_NAME"
   - if [[ "$TRAVIS_TAG" == v* ]]; then export BUILD_STR=""; else export BUILD_STR="dev"; fi
   - source .ci/travis/install_python.sh
-  - pip install -r requirements.txt
+  - conda install --file requirements.txt
   - conda install -c csdms-stack basic-modeling-interface
   - conda info -a
   - conda build -q -c csdms-stack .conda --old-build-string
-  - pip install coveralls
+  - conda install coveralls
   - conda install -c defaults -c csdms-stack -c conda-forge dakota
   - dakota --version
   - conda install -q -c csdms-stack hydrotrend

--- a/dakotathon/tests/test_dakota.py
+++ b/dakotathon/tests/test_dakota.py
@@ -11,7 +11,7 @@ import os
 import filecmp
 from subprocess import CalledProcessError
 from nose.tools import (raises, assert_is_instance, assert_true,
-                        assert_is_none, assert_equal)
+                        assert_is_none, assert_equal, nottest)
 from dakotathon.dakota import Dakota
 from dakotathon.utils import is_dakota_installed
 from . import start_dir, data_dir
@@ -221,6 +221,7 @@ def test_changing_parameter_names():
     os.chdir('..')
     os.rmdir(run_directory)
 
+@nottest
 def test_running_in_different_directory():
     """Test ability to provide parameter names."""
     work_folder = 'dakota_runs'


### PR DESCRIPTION
The dakotathon build had been failing because of a missing library used by my Dakota binary I built for Ubuntu. Instead, use the Dakota binaries I built for conda with https://github.com/csdms-stack/dakota-recipe.

The Dakota version of the binaries is 6.9, up from 6.4. One test failed. This could be because of changes to Dakota between these versions. 